### PR TITLE
Add editor and explorer context menu duplicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,20 @@
         {
           "command": "fileutils.moveFile",
           "group": "edit"
+        },
+        {
+          "command": "fileutils.duplicateFile",
+          "group": "edit"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "fileutils.moveFile",
+          "group": "edit"
+        },
+        {
+          "command": "fileutils.duplicateFile",
+          "group": "edit"
         }
       ]
     }
@@ -102,8 +116,8 @@
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "tslint": "^3.13.0",
-    "typescript": "^1.8.10",
-    "vscode": "^0.11.14"
+    "typescript": "^2.0.3",
+    "vscode": "^1.0.0"
   },
   "dependencies": {
     "fs-extra-promise": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-fileutils",
   "displayName": "File Utils",
   "description": "A convenient way of creating, moving, renaming and deleting files and directories.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "publisher": "sleistner",
   "engines": {

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -34,9 +34,9 @@ export function renameFile() {
         .catch(handleError);
 }
 
-export function duplicateFile() {
+export function duplicateFile(uri?: Uri) {
 
-    return controller.showMoveFileDialog({ prompt: 'Duplicate As', showFullPath: true })
+    return controller.showMoveFileDialog({ prompt: 'Duplicate As', showFullPath: true, uri })
         .then(fileItem => controller.duplicate(fileItem))
         .then(newFile => controller.openFileInEditor(newFile))
         .catch(handleError);

--- a/test/commands/duplicate-file.test.ts
+++ b/test/commands/duplicate-file.test.ts
@@ -224,6 +224,46 @@ describe('duplicateFile', () => {
 
     });
 
+    describe('as context menu', () => {
+
+        beforeEach(() => {
+            sinon.stub(window, 'showInputBox').returns(Promise.resolve(targetFile));
+            return Promise.resolve();
+        });
+
+        afterEach(() => {
+            const stub: any = window.showInputBox;
+            return Promise.resolve(stub.restore());
+        });
+
+        it('prompts for file destination', () => {
+
+            return duplicateFile(Uri.file(editorFile1)).then(() => {
+                const prompt = 'New Location';
+                const value = editorFile1;
+                expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value });
+            });
+
+        });
+
+        it('duplicates current file to destination', () => {
+
+            return duplicateFile(Uri.file(editorFile1)).then(() => {
+                const message = `${targetFile} does not exist`;
+                expect(fs.existsSync(targetFile), message).to.be.true;
+            });
+        });
+
+        it('opens target file as active editor', () => {
+
+            return duplicateFile(Uri.file(editorFile1)).then(() => {
+                const activeEditor: TextEditor = window.activeTextEditor;
+                expect(activeEditor.document.fileName).to.equal(targetFile);
+            });
+        });
+
+    });
+
     describe('error handling', () => {
 
         beforeEach(() => {


### PR DESCRIPTION
This PR adds support for `Move File` and `Duplicate File` context menus in file explorer and editor context.

#7 