### PR TITLE
Extract normailized fs path for file dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.3 (2017-01-12)
+
+### Fixes:
+ 
+ - File-Duplicate from the context menu doesn't work on Windows
+
 ## 2.3.1 (2016-10-14)
 
 ### Features:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-fileutils",
   "displayName": "File Utils",
   "description": "A convenient way of creating, duplicating, moving, renaming and deleting files and directories.",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "license": "MIT",
   "publisher": "sleistner",
   "engines": {

--- a/src/extension/api/controller.ts
+++ b/src/extension/api/controller.ts
@@ -27,7 +27,7 @@ export class FileController {
 
         const executor = (resolve, reject) => {
 
-            const sourcePath = uri ? uri.path : this.sourcePath;
+            const sourcePath = uri ? uri.fsPath : this.sourcePath;
 
             if (!sourcePath) {
                 return reject();


### PR DESCRIPTION
This PR ensures the usage of a normailized fs path for file dialogs.

Fixes #10 