### PR TITLE
Remove tab context modifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ stages:
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+      chmod 755 ./travis-tool.sh
+      ./travis-tool.sh bootstrap
+      sudo apt-get install xclip xsel --no-install-recommends --yes
+      sudo apt-get install pandoc
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
       sudo apt-get --assume-yes install libsecret-1-0;
       sh -e /etc/init.d/xvfb start;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ stages:
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-      chmod 755 ./travis-tool.sh
-      ./travis-tool.sh bootstrap
-      sudo apt-get install xclip xsel --no-install-recommends --yes
-      sudo apt-get install pandoc
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
       sudo apt-get --assume-yes install libsecret-1-0;
       sh -e /etc/init.d/xvfb start;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ stages:
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sudo apt-get --assume-yes install libsecret-1-0;
+      sudo apt-get --assume-yes install libsecret-1-0 xclip;
       sh -e /etc/init.d/xvfb start;
       sleep 3;
     fi

--- a/package.json
+++ b/package.json
@@ -122,17 +122,13 @@
         {
           "command": "fileutils.duplicateFile",
           "group": "1_modification"
+        },
+        {
+          "command": "fileutils.renameFile",
+          "group": "1_modification"
         }
       ],
       "editor/title/context": [
-        {
-          "command": "fileutils.renameFile",
-          "group": "7_modification"
-        },
-        {
-          "command": "fileutils.removeFile",
-          "group": "7_modification"
-        },
         {
           "command": "fileutils.copyFileName",
           "group": "1_copypath"

--- a/src/command/CopyFileNameCommand.ts
+++ b/src/command/CopyFileNameCommand.ts
@@ -1,6 +1,6 @@
 import { Uri } from 'vscode';
 import { CopyFileNameController, IFileController } from '../controller';
-import { FileItem } from '../Item';
+import { ICopyFileNameDialogOptions } from '../controller/CopyFileNameController';
 import { BaseCommand } from './BaseCommand';
 
 export class CopyFileNameCommand extends BaseCommand {
@@ -10,12 +10,8 @@ export class CopyFileNameCommand extends BaseCommand {
     }
 
     public async execute(uri?: Uri) {
-        const sourcePath = await this.controller.getSourcePath();
-        if (!sourcePath) {
-            return;
-        }
-
-        const fileItem = new FileItem(sourcePath);
+        const dialogOptions: ICopyFileNameDialogOptions = { uri };
+        const fileItem = await this.controller.showDialog(dialogOptions);
         return this.controller.execute({ fileItem });
     }
 }

--- a/src/controller/CopyFileNameController.ts
+++ b/src/controller/CopyFileNameController.ts
@@ -1,12 +1,21 @@
+import { Uri } from 'vscode';
 import { ClipboardUtil } from '../ClipboardUtil';
 import { FileItem } from '../Item';
 import { BaseFileController } from './BaseFileController';
-import { IExecuteOptions } from './FileController';
+import { IDialogOptions, IExecuteOptions } from './FileController';
+
+export interface ICopyFileNameDialogOptions extends IDialogOptions {
+    uri?: Uri;
+}
 
 export class CopyFileNameController extends BaseFileController {
-    // Not relevant to CopyFileNameController as it need no dialog
-    public async showDialog(): Promise<FileItem> {
-        const sourcePath = await this.getSourcePath();
+
+    public async showDialog(options: ICopyFileNameDialogOptions): Promise<FileItem> {
+        const { uri = null } = options;
+        const sourcePath = uri && uri.fsPath || await this.getSourcePath();
+        if (!sourcePath) {
+            throw new Error();
+        }
         return new FileItem(sourcePath);
     }
 

--- a/src/controller/FileController.ts
+++ b/src/controller/FileController.ts
@@ -2,7 +2,7 @@ import { TextEditor } from 'vscode';
 import { FileItem } from '../Item';
 
 export interface IDialogOptions {
-    prompt: string;
+    prompt?: string;
 }
 
 export interface IExecuteOptions {


### PR DESCRIPTION
This PR introduces a breaking change as all modification command are removed from file tab context menu in order to better align with VSCode standards.

Closes: #120 
Closes: #121 