### PR TITLE
NewFileCommand - fix: show folder selector

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--folder-uri=/tmp"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/src/**/*.js"

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "semantic-release-vsce": "^2.2.8",
     "sinon": "^7.4.1",
     "sinon-chai": "^3.3.0",
-    "tslint": "^5.12.1",
+    "tslint": "^5.19.0",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "typescript": "^3.5.3",
     "vscode-test": "^1.2.0"

--- a/src/controller/BaseFileController.ts
+++ b/src/controller/BaseFileController.ts
@@ -1,7 +1,7 @@
 import { commands, env, ExtensionContext, TextEditor, ViewColumn, window, workspace } from 'vscode';
 import { FileItem } from '../FileItem';
 import { Cache } from '../lib/Cache';
-import { IDialogOptions, IExecuteOptions, IFileController } from './FileController';
+import { IDialogOptions, IExecuteOptions, IFileController, IGetSourcePathOptions } from './FileController';
 
 export abstract class BaseFileController implements IFileController {
     constructor(protected context: ExtensionContext) { }
@@ -32,7 +32,7 @@ export abstract class BaseFileController implements IFileController {
         return commands.executeCommand('workbench.action.closeActiveEditor');
     }
 
-    public async getSourcePath(): Promise<string> {
+    public async getSourcePath(options?: IGetSourcePathOptions): Promise<string> {
         // Attempting to get the fileName from the activeTextEditor.
         // Works for text files only.
         const activeEditor = window.activeTextEditor;

--- a/src/controller/FileController.ts
+++ b/src/controller/FileController.ts
@@ -9,10 +9,14 @@ export interface IExecuteOptions {
     fileItem: FileItem;
 }
 
+export interface IGetSourcePathOptions {
+    relativeToRoot?: boolean;
+}
+
 export interface IFileController {
     showDialog(options?: IDialogOptions): Promise<FileItem | undefined>;
     execute(options: IExecuteOptions): Promise<FileItem>;
     openFileInEditor(fileItem: FileItem): Promise<TextEditor | undefined>;
     closeCurrentFileEditor(): Promise<any>;
-    getSourcePath(): Promise<string>;
+    getSourcePath(options?: IGetSourcePathOptions): Promise<string>;
 }

--- a/src/lib/TreeWalker.ts
+++ b/src/lib/TreeWalker.ts
@@ -1,32 +1,24 @@
-import * as fs from 'fs';
-import { sync as globSync } from 'glob';
+import * as glob from 'glob';
 import * as path from 'path';
-import { workspace } from 'vscode';
+import { Uri, workspace } from 'vscode';
 import { getConfiguration } from '../lib/config';
 
 export class TreeWalker {
 
     public async directories(sourcePath: string): Promise<string[]> {
-        const ignore = this.configIgnoredGlobs()
-            .map(this.invertGlob);
-
-        const results = globSync('**', { cwd: sourcePath, ignore })
-            .filter((file) => fs.statSync(path.join(sourcePath, file)).isDirectory())
-            .map((file) => path.sep + file);
-
-        return results;
+        return glob
+            .sync('**/', { cwd: sourcePath, ignore: this.configIgnore() })
+            .map((file) => path.sep + file.replace(/\/$/, ''));
     }
 
-    private configIgnoredGlobs(): string[] {
-        const configFilesExclude = {
+    private configIgnore(): string[] {
+        const excludedFilesConfig = {
             ...getConfiguration('typeahead.exclude'),
             ...workspace.getConfiguration('files.exclude', null)
         };
-        return Object.keys(configFilesExclude)
-            .filter((key) => configFilesExclude[key] === true);
-    }
-
-    private invertGlob(pattern: string) {
-        return pattern.replace(/^!/, '');
+        return Object
+            .keys(excludedFilesConfig)
+            .filter((key) => excludedFilesConfig[key] === true)
+            .map(((pattern) => pattern.replace(/^!/, '')));
     }
 }

--- a/test/command/MoveFileCommand.test.ts
+++ b/test/command/MoveFileCommand.test.ts
@@ -32,7 +32,6 @@ describe('MoveFileCommand', () => {
                 extra() {
                     describe('configuration', () => {
                         beforeEach(async () => {
-                            helper.createGetConfigurationStub();
                             helper.createExecuteCommandStub().withArgs('workbench.action.closeActiveEditor');
                         });
 
@@ -43,9 +42,7 @@ describe('MoveFileCommand', () => {
 
                         describe('move.closeOldTab set to true', () => {
                             beforeEach(async () => {
-                                const keys: { [key: string]: boolean } = { 'move.closeOldTab': true };
-                                const config = { get: (key: string) => keys[key] };
-                                helper.createGetConfigurationStub().returns(config);
+                                helper.createGetConfigurationStub({ 'move.closeOldTab': true });
                             });
 
                             it('moves a file and verifies that the tab of the file was closed', async () => {
@@ -56,9 +53,7 @@ describe('MoveFileCommand', () => {
 
                         describe('move.closeOldTab set to false', () => {
                             beforeEach(async () => {
-                                const keys: { [key: string]: boolean } = { 'move.closeOldTab': false };
-                                const config = { get: (key: string) => keys[key] };
-                                helper.createGetConfigurationStub().returns(config);
+                                helper.createGetConfigurationStub({ 'move.closeOldTab': false });
                             });
 
                             it('moves a file and verifies that the tab of the file was not closed', async () => {

--- a/test/command/NewFileCommand.test.ts
+++ b/test/command/NewFileCommand.test.ts
@@ -37,8 +37,6 @@ describe('NewFileCommand', () => {
 
         describe('configuration', () => {
             beforeEach(async () => {
-                helper.createGetConfigurationStub();
-
                 await workspace.fs.createDirectory(Uri.file(path.resolve(helper.tmpDir.fsPath, 'dir-1')));
                 await workspace.fs.createDirectory(Uri.file(path.resolve(helper.tmpDir.fsPath, 'dir-2')));
             });
@@ -49,9 +47,7 @@ describe('NewFileCommand', () => {
 
             describe('typeahead.enabled set to true', () => {
                 beforeEach(async () => {
-                    const keys: { [key: string]: boolean } = { 'typeahead.enabled': true };
-                    const config = { get: (key: string) => keys[key] };
-                    helper.createGetConfigurationStub().returns(config);
+                    helper.createGetConfigurationStub({ 'typeahead.enabled': true });
                 });
 
                 it('shows the quick pick dialog', async () => {
@@ -66,9 +62,7 @@ describe('NewFileCommand', () => {
 
             describe('typeahead.enabled set to false', () => {
                 beforeEach(async () => {
-                    const keys: { [key: string]: boolean } = { 'typeahead.enabled': false };
-                    const config = { get: (key: string) => keys[key] };
-                    helper.createGetConfigurationStub().returns(config);
+                    helper.createGetConfigurationStub({ 'typeahead.enabled': false });
                 });
 
                 it('shows the quick pick dialog', async () => {
@@ -158,8 +152,6 @@ describe('NewFileCommand', () => {
 
             describe('configuration', () => {
                 beforeEach(async () => {
-                    helper.createGetConfigurationStub();
-
                     await workspace.fs.createDirectory(Uri.file(path.resolve(workspaceFolderA.uri.fsPath, 'dir-1')));
                     await workspace.fs.createDirectory(Uri.file(path.resolve(workspaceFolderA.uri.fsPath, 'dir-2')));
                 });
@@ -170,9 +162,7 @@ describe('NewFileCommand', () => {
 
                 describe('typeahead.enabled set to true', () => {
                     beforeEach(async () => {
-                        const keys: { [key: string]: boolean } = { 'typeahead.enabled': true };
-                        const config = { get: (key: string) => keys[key] };
-                        helper.createGetConfigurationStub().returns(config);
+                        helper.createGetConfigurationStub({ 'typeahead.enabled': true });
                     });
 
                     it('shows the quick pick dialog', async () => {
@@ -187,9 +177,7 @@ describe('NewFileCommand', () => {
 
                 describe('typeahead.enabled set to false', () => {
                     beforeEach(async () => {
-                        const keys: { [key: string]: boolean } = { 'typeahead.enabled': false };
-                        const config = { get: (key: string) => keys[key] };
-                        helper.createGetConfigurationStub().returns(config);
+                        helper.createGetConfigurationStub({ 'typeahead.enabled': false });
                     });
 
                     it('shows the quick pick dialog', async () => {
@@ -242,8 +230,6 @@ describe('NewFileCommand', () => {
 
             describe('configuration', () => {
                 beforeEach(async () => {
-                    helper.createGetConfigurationStub();
-
                     await workspace.fs.createDirectory(Uri.file(path.resolve(workspaceFolderB.uri.fsPath, 'dir-1')));
                     await workspace.fs.createDirectory(Uri.file(path.resolve(workspaceFolderB.uri.fsPath, 'dir-2')));
                 });
@@ -254,9 +240,7 @@ describe('NewFileCommand', () => {
 
                 describe('typeahead.enabled set to true', () => {
                     beforeEach(async () => {
-                        const keys: { [key: string]: boolean } = { 'typeahead.enabled': true };
-                        const config = { get: (key: string) => keys[key] };
-                        helper.createGetConfigurationStub().returns(config);
+                        helper.createGetConfigurationStub({ 'typeahead.enabled': true });
                     });
 
                     it('shows the quick pick dialog', async () => {
@@ -271,9 +255,7 @@ describe('NewFileCommand', () => {
 
                 describe('typeahead.enabled set to false', () => {
                     beforeEach(async () => {
-                        const keys: { [key: string]: boolean } = { 'typeahead.enabled': false };
-                        const config = { get: (key: string) => keys[key] };
-                        helper.createGetConfigurationStub().returns(config);
+                        helper.createGetConfigurationStub({ 'typeahead.enabled': false });
                     });
 
                     it('shows the quick pick dialog', async () => {

--- a/test/command/RemoveFileCommand.test.ts
+++ b/test/command/RemoveFileCommand.test.ts
@@ -27,15 +27,11 @@ describe('RemoveFileCommand', () => {
             });
 
             describe('configuration', () => {
-                beforeEach(async () => helper.createGetConfigurationStub());
-
                 afterEach(async () => helper.restoreGetConfiguration());
 
                 describe('delete.useTrash set to false', () => {
                     beforeEach(async () => {
-                        const keys: { [key: string]: boolean } = { 'delete.useTrash': false, 'delete.confirm': true };
-                        const config = { get: (key: string) => keys[key] };
-                        helper.createGetConfigurationStub().returns(config);
+                        helper.createGetConfigurationStub({ 'delete.useTrash': false, 'delete.confirm': true });
                     });
 
                     it('asks to delete file', async () => {
@@ -49,9 +45,7 @@ describe('RemoveFileCommand', () => {
 
                 describe('delete.useTrash set to true', () => {
                     beforeEach(async () => {
-                        const keys: { [key: string]: boolean } = { 'delete.useTrash': true, 'delete.confirm': true };
-                        const config = { get: (key: string) => keys[key] };
-                        helper.createGetConfigurationStub().returns(config);
+                        helper.createGetConfigurationStub({ 'delete.useTrash': true, 'delete.confirm': true });
                     });
 
                     it('asks to move file to trash', async () => {
@@ -88,9 +82,7 @@ describe('RemoveFileCommand', () => {
 
             describe('delete.confirm configuration set to false', () => {
                 beforeEach(async () => {
-                    const keys: { [key: string]: boolean } = { 'delete.useTrash': false, 'delete.confirm': false };
-                    const config = { get: (key: string) => keys[key] };
-                    helper.createGetConfigurationStub().returns(config);
+                    helper.createGetConfigurationStub({ 'delete.useTrash': false, 'delete.confirm': false });
                 });
 
                 afterEach(async () => helper.restoreGetConfiguration());

--- a/test/command/RenameFileCommand.test.ts
+++ b/test/command/RenameFileCommand.test.ts
@@ -39,7 +39,6 @@ describe('RenameFileCommand', () => {
 
                     describe('configuration', () => {
                         beforeEach(async () => {
-                            helper.createGetConfigurationStub();
                             helper.createExecuteCommandStub().withArgs('workbench.action.closeActiveEditor');
                         });
 
@@ -50,9 +49,7 @@ describe('RenameFileCommand', () => {
 
                         describe('rename.closeOldTab set to true', () => {
                             beforeEach(async () => {
-                                const keys: { [key: string]: boolean } = { 'rename.closeOldTab': true };
-                                const config = { get: (key: string) => keys[key] };
-                                helper.createGetConfigurationStub().returns(config);
+                                helper.createGetConfigurationStub({ 'rename.closeOldTab': true });
                             });
 
                             it('renames a file and verifies that the tab of the file was closed', async () => {
@@ -63,9 +60,7 @@ describe('RenameFileCommand', () => {
 
                         describe('rename.closeOldTab set to false', () => {
                             beforeEach(async () => {
-                                const keys: { [key: string]: boolean } = { 'rename.closeOldTab': false };
-                                const config = { get: (key: string) => keys[key] };
-                                helper.createGetConfigurationStub().returns(config);
+                                helper.createGetConfigurationStub({ 'rename.closeOldTab': false });
                             });
 
                             it('renames a file and verifies that the tab of the file was not closed', async () => {

--- a/test/helper/stubs.ts
+++ b/test/helper/stubs.ts
@@ -9,8 +9,9 @@ export function restoreExecuteCommand() {
     restoreObject(commands.executeCommand);
 }
 
-export function createGetConfigurationStub(): sinon.SinonStub {
-    return createStubObject(workspace, 'getConfiguration');
+export function createGetConfigurationStub(keys: { [key: string]: boolean }): sinon.SinonStub {
+    const config = { get: (key: string) => keys[key] };
+    return createStubObject(workspace, 'getConfiguration').returns(config);
 }
 
 export function restoreGetConfiguration() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,9 +100,9 @@
     lodash "^4.17.4"
 
 "@semantic-release/commit-analyzer@^6.1.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-6.2.0.tgz#5cd25ce67ba9ba5b46e47457505e63629e186695"
-  integrity sha512-oUtPydYcbtJsEY6WCPi4wynTgRecK5zCkKaGmHi+9Xl7d6jGf7LomnJCg++6dNF1tyavrbGMSdXTCPH6Dx9LbA==
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-6.3.0.tgz#e0fb2f6af7be2321ad9401d8ae25be0cc1005d83"
+  integrity sha512-sh51MVlV8VyrvGIemcvzueDADX/8qGbAgce1F0CtQv8hNKYyhdaJeHzfiM1rNXwCynDmcQj+Yq9rrWt71tBd/Q==
   dependencies:
     conventional-changelog-angular "^5.0.0"
     conventional-commits-filter "^2.0.0"
@@ -173,9 +173,9 @@
     registry-auth-token "^4.0.0"
 
 "@semantic-release/release-notes-generator@^7.1.2":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@semantic-release/release-notes-generator/-/release-notes-generator-7.2.1.tgz#2c0c340e7be2a3d27c28cb869b6737a70f2862fe"
-  integrity sha512-TdlYgYH6amhE80i9L9HPcTwYzk4Rma7qM1g7XJEEfip7dNXWgmrBeibN4DJmTg/qrUFDd4GD86lFDcYXNZDNow==
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/release-notes-generator/-/release-notes-generator-7.3.0.tgz#b94f3d84d7071eb8e921b53a9729ca48722e7c0f"
+  integrity sha512-6ozBLHM9XZR6Z8PFSKssLtwBYc5l1WOnxj034F8051QOo3TMKDDPKwdj2Niyc+e7ru7tGa3Ftq7nfN0YnD6//A==
   dependencies:
     conventional-changelog-angular "^5.0.0"
     conventional-changelog-writer "^4.0.0"
@@ -188,10 +188,10 @@
     lodash "^4.17.4"
     read-pkg-up "^6.0.0"
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
-  integrity sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
+  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
   dependencies:
     type-detect "4.0.8"
 
@@ -204,13 +204,13 @@
     "@sinonjs/samsam" "^3.1.0"
 
 "@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.2.tgz#63942e3d5eb0b79f6de3bef9abfad15fb4b6401b"
-  integrity sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
   dependencies:
-    "@sinonjs/commons" "^1.0.2"
+    "@sinonjs/commons" "^1.3.0"
     array-from "^2.1.1"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
 
 "@sinonjs/text-encoding@^0.7.1":
   version "0.7.1"
@@ -259,9 +259,9 @@
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
 "@types/node@*":
-  version "12.7.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.1.tgz#3b5c3a26393c19b400844ac422bd0f631a94d69d"
-  integrity sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==
+  version "12.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
+  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
 
 "@types/node@^10.12.21":
   version "10.14.15"
@@ -532,14 +532,14 @@ before-after-hook@^2.0.0:
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
 bin-links@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-1.1.2.tgz#fb74bd54bae6b7befc6c6221f25322ac830d9757"
-  integrity sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-1.1.3.tgz#702fd59552703727313bc624bdbc4c0d3431c2ca"
+  integrity sha512-TEwmH4PHU/D009stP+fkkazMJgkBNCv60z01lQ/Mn8E6+ThHoD03svMnBVuCowwXo2nP2qKyKZxKxp58OHRzxw==
   dependencies:
-    bluebird "^3.5.0"
-    cmd-shim "^2.0.2"
-    gentle-fs "^2.0.0"
-    graceful-fs "^4.1.11"
+    bluebird "^3.5.3"
+    cmd-shim "^3.0.0"
+    gentle-fs "^2.0.1"
+    graceful-fs "^4.1.15"
     write-file-atomic "^2.3.0"
 
 bluebird-retry@^0.11.0:
@@ -547,7 +547,7 @@ bluebird-retry@^0.11.0:
   resolved "https://registry.yarnpkg.com/bluebird-retry/-/bluebird-retry-0.11.0.tgz#1289ab22cbbc3a02587baad35595351dd0c1c047"
   integrity sha1-EomrIsu8OgJYe6rTVZU1HdDBwEc=
 
-bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
+bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
   integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
@@ -631,9 +631,9 @@ byte-size@^5.0.1:
   integrity sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==
 
 cacache@^12.0.0, cacache@^12.0.2:
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.2.tgz#8db03205e36089a3df6954c66ce92541441ac46c"
-  integrity sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==
+  version "12.0.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
+  integrity sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==
   dependencies:
     bluebird "^3.5.5"
     chownr "^1.1.1"
@@ -830,7 +830,15 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-cmd-shim@^2.0.2, cmd-shim@~2.0.2:
+cmd-shim@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-3.0.0.tgz#738b3532187238c4b69682345c2ad930e99b7750"
+  integrity sha512-9cl9KcmjzrOZhA/mLl2qwhFaPLr6HpbbuPjMWPdDQ7EVrIOQJsI1JvzMur87mgaeCAtwRb5WNS2SBnC9uZDWwg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    mkdirp "~0.5.0"
+
+cmd-shim@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
   integrity sha1-b8vamUg6j9FdfTChlspp1oii79s=
@@ -1682,15 +1690,17 @@ genfun@^5.0.0:
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
   integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
 
-gentle-fs@^2.0.0, gentle-fs@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/gentle-fs/-/gentle-fs-2.0.1.tgz#585cfd612bfc5cd52471fdb42537f016a5ce3687"
-  integrity sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==
+gentle-fs@^2.0.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/gentle-fs/-/gentle-fs-2.2.1.tgz#1f38df4b4ead685566257201fd526de401ebb215"
+  integrity sha512-e7dRgUM5fsS+7wm2oggZpgcRx6sEvJHXujPH5RzgQ1ziQY4+HuVBYsnUzJwJ+C7mjOJN27DjiFy1TaL+TNltow==
   dependencies:
     aproba "^1.1.2"
+    chownr "^1.1.2"
     fs-vacuum "^1.2.10"
     graceful-fs "^4.1.11"
     iferr "^0.1.5"
+    infer-owner "^1.0.4"
     mkdirp "^0.5.1"
     path-is-inside "^1.0.2"
     read-cmd-shim "^1.0.1"
@@ -1824,9 +1834,9 @@ got@^6.7.1:
     url-parse-lax "^1.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.1.tgz#1c1f0c364882c868f5bff6512146328336a11b1d"
-  integrity sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
 growl@1.10.5:
   version "1.10.5"
@@ -1894,10 +1904,15 @@ hook-std@^2.0.0:
   resolved "https://registry.yarnpkg.com/hook-std/-/hook-std-2.0.0.tgz#ff9aafdebb6a989a354f729bb6445cf4a3a7077c"
   integrity sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.6.0, hosted-git-info@^2.7.1, hosted-git-info@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.2.tgz#a35c3f355ac1249f1093c0c2a542ace8818c171a"
-  integrity sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==
+hosted-git-info@^2.1.4, hosted-git-info@^2.6.0, hosted-git-info@^2.8.2:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
+  integrity sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
+
+hosted-git-info@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.0.tgz#dd8af49cd01e73cc8e61ba13e217a772fd4ecd2d"
+  integrity sha512-zYSx1cP4MLsvKtTg8DF/PI6e6FHZ3wcawcTGsrLU2TM+UfD4jmSrn2wdQT16TFbH3lO4PIdjLG0E+cuYDgFD9g==
   dependencies:
     lru-cache "^5.1.1"
 
@@ -1975,9 +1990,9 @@ ignore-walk@^3.0.1:
     minimatch "^3.0.4"
 
 ignore@^5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.2.tgz#e28e584d43ad7e92f96995019cc43b9e1ac49558"
-  integrity sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -2358,9 +2373,9 @@ lcid@^2.0.0:
     invert-kv "^2.0.0"
 
 libcipm@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/libcipm/-/libcipm-4.0.0.tgz#30053bee09b0b1f4df855137d631a6d27f5d59de"
-  integrity sha512-5IIamvUIqWYjfNscYdirKisXyaTMw7Mf7yuGrjHH2isz7xBZDCUOIdujZxNk2g6lBBs8AGxYW6lHpNnnt92bww==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/libcipm/-/libcipm-4.0.3.tgz#6a6db4a6e040e56f4af18bb1d664e05e8eb23a39"
+  integrity sha512-nuIxNtqA+kIkwUiNM/nZ0yPyR7NkSUov6g6mCfFPkYylO1dEovZBL+NZ3axdouS2UOTa8GdnJ7/meSc1/0AIGw==
   dependencies:
     bin-links "^1.1.2"
     bluebird "^3.5.1"
@@ -2634,7 +2649,7 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3101,9 +3116,9 @@ npm-install-checks@~3.0.0:
     semver "^2.3.0 || 3.x || 4 || 5"
 
 npm-lifecycle@^3.0.0, npm-lifecycle@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-3.1.2.tgz#06f2253ea3b9e122ce3e55e3496670a810afcc84"
-  integrity sha512-nhfOcoTHrW1lJJlM2o77vTE2RWR4YOVyj7YzmY0y5itsMjEuoJHteio/ez0BliENEPsNxIUQgwhyEW9dShj3Ww==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-3.1.3.tgz#09e9b0b6686e85fd53bab82364386222d97a3730"
+  integrity sha512-M0QmmqbEHBXxDrmc6X3+eKjW9+F7Edg1ENau92WkYw1sox6wojHzEZJIRm1ItljEiaigZlKL8mXni/4ylAy1Dg==
   dependencies:
     byline "^5.0.0"
     graceful-fs "^4.1.15"
@@ -3141,6 +3156,15 @@ npm-pick-manifest@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz#32111d2a9562638bb2c8f2bf27f7f3092c8fae40"
   integrity sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    npm-package-arg "^6.0.0"
+    semver "^5.4.1"
+
+npm-pick-manifest@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-3.0.0.tgz#c94cab52d201a85875e45198fffe1a8a348e7af7"
+  integrity sha512-H+OnFudiq38Qj8P8xcesD/1Xa0Kvr2QRn1DTlephIwNfJg3P30Szc1wtpGEgdPXfAyKZKT2ajIM2X8YtCrbXrA==
   dependencies:
     figgy-pudding "^3.5.1"
     npm-package-arg "^6.0.0"
@@ -3459,9 +3483,9 @@ p-limit@^1.1.0:
     p-try "^1.0.0"
 
 p-limit@^2.0.0, p-limit@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
-  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
+  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
   dependencies:
     p-try "^2.0.0"
 
@@ -3525,15 +3549,17 @@ package-json@^4.0.0:
     semver "^5.1.0"
 
 pacote@^9.1.0, pacote@^9.5.3, pacote@^9.5.4:
-  version "9.5.4"
-  resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.5.4.tgz#8baa26f3d1326d13dc2fe0fe84040a364ae30aad"
-  integrity sha512-nWr0ari6E+apbdoN0hToTKZElO5h4y8DGFa2pyNA5GQIdcP0imC96bA0bbPw1gpeguVIiUgHHaAlq/6xfPp8Qw==
+  version "9.5.8"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.5.8.tgz#23480efdc4fa74515855c9ecf39cf64078f99786"
+  integrity sha512-0Tl8Oi/K0Lo4MZmH0/6IsT3gpGf9eEAznLXEQPKgPq7FscnbUOyopnVpwXlnQdIbCUaojWy1Wd7VMyqfVsRrIw==
   dependencies:
     bluebird "^3.5.3"
-    cacache "^12.0.0"
+    cacache "^12.0.2"
+    chownr "^1.1.2"
     figgy-pudding "^3.5.1"
     get-stream "^4.1.0"
     glob "^7.1.3"
+    infer-owner "^1.0.4"
     lru-cache "^5.1.1"
     make-fetch-happen "^5.0.0"
     minimatch "^3.0.4"
@@ -3543,7 +3569,7 @@ pacote@^9.1.0, pacote@^9.5.3, pacote@^9.5.4:
     normalize-package-data "^2.4.0"
     npm-package-arg "^6.1.0"
     npm-packlist "^1.1.12"
-    npm-pick-manifest "^2.2.3"
+    npm-pick-manifest "^3.0.0"
     npm-registry-fetch "^4.0.0"
     osenv "^0.1.5"
     promise-inflight "^1.0.1"
@@ -3553,7 +3579,7 @@ pacote@^9.1.0, pacote@^9.5.3, pacote@^9.5.4:
     safe-buffer "^5.1.2"
     semver "^5.6.0"
     ssri "^6.0.1"
-    tar "^4.4.8"
+    tar "^4.4.10"
     unique-filename "^1.1.1"
     which "^1.3.1"
 
@@ -3829,9 +3855,9 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     strip-json-comments "~2.0.1"
 
 read-cmd-shim@^1.0.1, read-cmd-shim@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
-  integrity sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.3.tgz#b246608c8e76e332a99be7811c096a4baf60015a"
+  integrity sha512-HUHb2imlZ8xBJjiZZRx0Ag9JfZ3jxQRfORMQXWCDeHE6PCCnpQrMq6LhyNqEPnMXhMDDIyq/BK7pBbhNy9zDDA==
   dependencies:
     graceful-fs "^4.1.2"
 
@@ -3850,9 +3876,9 @@ read-installed@~4.0.3:
     graceful-fs "^4.1.2"
 
 "read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.0.13.tgz#2e82ebd9f613baa6d2ebe3aa72cefe3f68e41f4a"
-  integrity sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.1.0.tgz#e3d42e6c35ea5ae820d9a03ab0c7291217fc51d5"
+  integrity sha512-KLhu8M1ZZNkMcrq1+0UJbR8Dii8KZUqB0Sha4mOx/bknfKI/fyrQVrG/YIt2UOtG667sD8+ee4EXMM91W9dC+A==
   dependencies:
     glob "^7.1.1"
     json-parse-better-errors "^1.0.1"
@@ -4080,9 +4106,9 @@ reusify@^1.0.0:
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
 rimraf@2, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
@@ -4129,9 +4155,9 @@ semantic-release-vsce@^2.2.8:
     vsce "^1.57.0"
 
 semantic-release@^15.13.0:
-  version "15.13.19"
-  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-15.13.19.tgz#d1d05b3516fb8701d81f4e6b9be42bafffef13cb"
-  integrity sha512-6eqqAmzGaJWgP5R5IkWIQK9is+cWUp/A+pwzxf/YaG1hJv1eD25klUP7Y0fedsPOxxI8eLuDUVlEs7U8SOlK0Q==
+  version "15.13.21"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-15.13.21.tgz#d021c75f889cff75ae3410736942bee6c4557da7"
+  integrity sha512-3S9thQas28iv3NeHUqQVsDnxMcBGQICdxabeNnJ8BnbRBvCkgqCg3v9zo/+O5a8GCyxrgjtwJ2iWozL8SiIq1w==
   dependencies:
     "@semantic-release/commit-analyzer" "^6.1.0"
     "@semantic-release/error" "^2.2.0"
@@ -4148,8 +4174,8 @@ semantic-release@^15.13.0:
     get-stream "^5.0.0"
     git-log-parser "^1.2.0"
     hook-std "^2.0.0"
-    hosted-git-info "^2.7.1"
-    lodash "^4.17.4"
+    hosted-git-info "^3.0.0"
+    lodash "^4.17.15"
     marked "^0.7.0"
     marked-terminal "^3.2.0"
     p-locate "^4.0.0"
@@ -4173,9 +4199,9 @@ semver-regex@^2.0.0:
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^6.0.0:
   version "6.3.0"
@@ -4637,10 +4663,10 @@ tslint-no-unused-expression-chai@^0.1.4:
   dependencies:
     tsutils "^3.0.0"
 
-tslint@^5.12.1:
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.18.0.tgz#f61a6ddcf372344ac5e41708095bbf043a147ac6"
-  integrity sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==
+tslint@^5.19.0:
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.19.0.tgz#a2cbd4a7699386da823f6b499b8394d6c47bb968"
+  integrity sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"
@@ -4854,9 +4880,9 @@ util-promisify@^2.1.0:
     object.getownpropertydescriptors "^2.0.3"
 
 uuid@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This change addresses a behaviour were the folder selector (quick pick)
wasn't show under all circumstances.

Now, provided "typeahead.enabled" is set to be true, the folder selector
will be shown if more than one director is present at the desired
location.

Fixes: #109 