### PR TITLE
NewFileCommand: Ensure directory listing even for large directory structures

### DIFF
--- a/src/lib/TreeWalker.ts
+++ b/src/lib/TreeWalker.ts
@@ -1,14 +1,17 @@
+import * as fs from 'fs';
 import * as glob from 'glob';
 import * as path from 'path';
-import { Uri, workspace } from 'vscode';
+import { workspace } from 'vscode';
 import { getConfiguration } from '../lib/config';
 
 export class TreeWalker {
 
     public async directories(sourcePath: string): Promise<string[]> {
-        return glob
-            .sync('**/', { cwd: sourcePath, ignore: this.configIgnore() })
-            .map((file) => path.sep + file.replace(/\/$/, ''));
+        const ignore = this.configIgnore();
+        const files = glob.sync('**', { cwd: sourcePath, ignore });
+        return files
+            .filter((file) => fs.statSync(path.join(sourcePath, file)).isDirectory())
+            .map((file) => path.sep + file);
     }
 
     private configIgnore(): string[] {

--- a/test/command/NewFileCommand.test.ts
+++ b/test/command/NewFileCommand.test.ts
@@ -10,6 +10,9 @@ describe('NewFileCommand', () => {
 
     const subject = helper.createTestSubject(NewFileCommand, NewFileController);
 
+    const hint = 'larger projects may take a moment to load';
+    const expectedShowQuickPickPlaceHolder = `First, select an existing path to create relative to (${hint})`;
+
     beforeEach(helper.beforeEach);
 
     afterEach(helper.afterEach);
@@ -52,11 +55,16 @@ describe('NewFileCommand', () => {
 
                 it('shows the quick pick dialog', async () => {
                     await subject.execute();
-                    expect(window.showQuickPick).to.have.been.calledOnceWith([
-                        { description: '- current file', label: '/' },
-                        { description: undefined, label: '/dir-1' },
-                        { description: undefined, label: '/dir-2' }
-                    ]);
+                    expect(window.showQuickPick).to.have.been.calledOnceWithExactly(
+                        Promise.resolve([
+                            { description: '- current file', label: '/' },
+                            { description: undefined, label: '/dir-1' },
+                            { description: undefined, label: '/dir-2' }
+                        ]),
+                        {
+                            placeHolder: expectedShowQuickPickPlaceHolder
+                        }
+                    );
                 });
             });
 
@@ -167,11 +175,15 @@ describe('NewFileCommand', () => {
 
                     it('shows the quick pick dialog', async () => {
                         await subject.execute(undefined, { relativeToRoot: true });
-                        expect(window.showQuickPick).to.have.been.calledOnceWith([
-                            { description: '- workspace root', label: '/' },
-                            { description: undefined, label: '/dir-1' },
-                            { description: undefined, label: '/dir-2' }
-                        ]);
+                        expect(window.showQuickPick).to.have.been.calledOnceWith(
+                            Promise.resolve([
+                                { description: '- workspace root', label: '/' },
+                                { description: undefined, label: '/dir-1' },
+                                { description: undefined, label: '/dir-2' }
+                            ]), {
+                                placeHolder: expectedShowQuickPickPlaceHolder
+                            }
+                        );
                     });
                 });
 
@@ -245,11 +257,16 @@ describe('NewFileCommand', () => {
 
                     it('shows the quick pick dialog', async () => {
                         await subject.execute(undefined, { relativeToRoot: true });
-                        expect(window.showQuickPick).to.have.been.calledOnceWith([
-                            { description: '- workspace root', label: '/' },
-                            { description: undefined, label: '/dir-1' },
-                            { description: undefined, label: '/dir-2' }
-                        ]);
+                        expect(window.showQuickPick).to.have.been.calledOnceWith(
+                            Promise.resolve([
+                                { description: '- workspace root', label: '/' },
+                                { description: undefined, label: '/dir-1' },
+                                { description: undefined, label: '/dir-2' }
+                            ]),
+                            {
+                                placeHolder: expectedShowQuickPickPlaceHolder
+                            }
+                        );
                     });
                 });
 


### PR DESCRIPTION
This PR addresses a defect which caused the directory selector to fail on large file structures.

Fixes: #136 