### PR TITLE
Ensure `File: Delete` only closes related tabs

### DIFF
--- a/src/command/RemoveFileCommand.ts
+++ b/src/command/RemoveFileCommand.ts
@@ -6,8 +6,7 @@ export class RemoveFileCommand extends BaseCommand {
     public async execute(uri?: Uri) {
         const fileItem = await this.controller.showDialog();
         if (fileItem) {
-            await this.controller.execute({ fileItem });
-            return this.controller.closeCurrentFileEditor();
+            return this.controller.execute({ fileItem });
         }
     }
 

--- a/src/controller/RemoveFileController.ts
+++ b/src/controller/RemoveFileController.ts
@@ -14,7 +14,7 @@ export class RemoveFileController extends BaseFileController {
             throw new Error();
         }
 
-        if (!this.confirmDelete) {
+        if (this.confirmDelete === false) {
             return new FileItem(sourcePath);
         }
 


### PR DESCRIPTION
This PR addresses an issue where `File: Delete` called _close tab_ twice.

Fixes: #137 