### PR TITLE
fix(Treewalker): handle large directory structures safely

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,10 @@ vsc-extension-quickstart.md
 tsd.json
 *.vsix
 releases/**
+yarn-error.log
+yarn.lock
+.releaserc
+tslint.json
+.devcontainer/**
+.github/**
+node_modules/**

--- a/README.md
+++ b/README.md
@@ -134,11 +134,6 @@ Nonexistent folders are created automatically.
         "type": "boolean",
         "default": true,
         "description": "Controls if directory selector should be shown."
-    },
-    "fileutils.typeahead.exclude": {
-        "type": "object",
-        "default": {},
-        "description": "Configure glob patterns for excluding files and folders."
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-fileutils",
   "displayName": "File Utils",
   "description": "A convenient way of creating, duplicating, moving, renaming and deleting files and directories.",
-  "version": "2.14.9",
+  "version": "3.0.0-beta",
   "private": true,
   "license": "MIT",
   "publisher": "sleistner",
@@ -164,11 +164,6 @@
           "type": "boolean",
           "default": true,
           "description": "Controls if directory selector should be shown."
-        },
-        "fileutils.typeahead.exclude": {
-          "type": "object",
-          "default": {},
-          "description": "Configure glob patterns for excluding files and folders."
         }
       }
     }
@@ -190,7 +185,6 @@
     "@types/bluebird": "^3.5.20",
     "@types/bluebird-retry": "0.11.4",
     "@types/chai": "^4.2.0",
-    "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.6",
     "@types/node": "^10.12.21",
     "@types/sinon": "^7.0.3",
@@ -210,9 +204,7 @@
     "typescript": "^3.5.3",
     "vscode-test": "^1.2.0"
   },
-  "dependencies": {
-    "glob": "^7.1.2"
-  },
+  "dependencies": {},
   "pre-commit": [
     "lint",
     "test"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,9 +19,9 @@ import {
     RemoveFileController
 } from './controller';
 
-function handleError(err: any) {
-    if (err) {
-        vscode.window.showErrorMessage(err);
+function handleError(err: Error) {
+    if (err && err.message) {
+        vscode.window.showErrorMessage(err.message);
     }
     return err;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,7 +1783,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==


### PR DESCRIPTION
Replace all references to `glob` with `vscode.workspace.findFiles` in
order to further support remote development and complex directory
structures.

BREAKING CHANGE:
The configuration option `typeahead.exclude` has been
removed in favor of VS Code native `files.exclude` option.

Fixes: #136 