### PR TITLE
Trigger import updates when moving or renaming files

### DIFF
--- a/src/FileItem.ts
+++ b/src/FileItem.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { FileSystemError, Uri, workspace } from 'vscode';
+import { FileSystemError, Uri, workspace, WorkspaceEdit } from 'vscode';
 
 export class FileItem {
 
@@ -39,7 +39,10 @@ export class FileItem {
 
     public async move(): Promise<FileItem> {
         this.ensureTargetPath();
-        await workspace.fs.rename(this.path, this.targetPath!, { overwrite: true });
+
+        const edit = new WorkspaceEdit();
+        edit.renameFile(this.path, this.targetPath!, { overwrite: true });
+        await workspace.applyEdit(edit);
 
         this.SourcePath = this.targetPath!;
         return this;


### PR DESCRIPTION
# Description

When moving or renaming a file, VS Code did not update imports because of the use of `workspace.fs.rename()`. Switching to using `WorkspaceEdit.renameFile` will trigger those updates.

Fixes #251 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
