### PR TITLE
fix(Rename, Move): keep file in editor group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/sleistner/vscode-fileutils.svg?branch=master)](https://travis-ci.org/sleistner/vscode-fileutils)
 [![Dependency Status](https://david-dm.org/sleistner/vscode-fileutils.svg)](https://david-dm.org/sleistner/vscode-fileutils)
-[![Known Vulnerabilities](https://snyk.io/test/github/sleistner/vscode-fileutils/badge.svg)](https://snyk.io/test/github/sleistner/vscode-fileutils) 
+[![Known Vulnerabilities](https://snyk.io/test/github/sleistner/vscode-fileutils/badge.svg)](https://snyk.io/test/github/sleistner/vscode-fileutils)
 [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
@@ -111,26 +111,6 @@ Nonexistent folders are created automatically.
 
 ```json
 {
-    "fileutils.delete.useTrash": {
-        "type": "boolean",
-        "default": false,
-        "description": "Move file to the recycle bin instead of deleting it permanently."
-    },
-    "fileutils.delete.confirm": {
-        "type": "boolean",
-        "default": true,
-        "description": "Controls if it should ask for confirmation when deleting a file."
-    },
-    "fileutils.rename.closeOldTab": {
-          "type": "boolean",
-          "default": true,
-          "description": "Controls whether to close the tab of the renamed file (Will work only if 'Close On File Delete' setting is disabled)"
-    },
-    "fileutils.move.closeOldTab": {
-          "type": "boolean",
-          "default": true,
-          "description": "Controls whether to close the tab of the moved file (Will work only if 'Close On File Delete' setting is disabled)"
-    },
     "fileutils.typeahead.enabled": {
         "type": "boolean",
         "default": true,

--- a/package.json
+++ b/package.json
@@ -48,47 +48,47 @@
     "commands": [
       {
         "command": "fileutils.renameFile",
-        "category": "File",
+        "category": "File Utils",
         "title": "Rename"
       },
       {
         "command": "fileutils.moveFile",
-        "category": "File",
+        "category": "File Utils",
         "title": "Move"
       },
       {
         "command": "fileutils.duplicateFile",
-        "category": "File",
+        "category": "File Utils",
         "title": "Duplicate"
       },
       {
         "command": "fileutils.removeFile",
-        "category": "File",
+        "category": "File Utils",
         "title": "Delete"
       },
       {
         "command": "fileutils.newFile",
-        "category": "File",
+        "category": "File Utils",
         "title": "New File Relative to Current View"
       },
       {
         "command": "fileutils.newFileAtRoot",
-        "category": "File",
+        "category": "File Utils",
         "title": "New File Relative to Project Root"
       },
       {
         "command": "fileutils.newFolder",
-        "category": "File",
+        "category": "File Utils",
         "title": "New Folder Relative to Current View"
       },
       {
         "command": "fileutils.newFolderAtRoot",
-        "category": "File",
+        "category": "File Utils",
         "title": "New Folder Relative to Project Root"
       },
       {
         "command": "fileutils.copyFileName",
-        "category": "File",
+        "category": "File Utils",
         "title": "Copy Name"
       }
     ],
@@ -140,26 +140,6 @@
       "type": "object",
       "title": "Fileutils configuration",
       "properties": {
-        "fileutils.delete.useTrash": {
-          "type": "boolean",
-          "default": false,
-          "description": "Move file to the recycle bin instead of deleting it permanently."
-        },
-        "fileutils.delete.confirm": {
-          "type": "boolean",
-          "default": true,
-          "description": "Controls if it should ask for confirmation when deleting a file."
-        },
-        "fileutils.rename.closeOldTab": {
-          "type": "boolean",
-          "default": true,
-          "description": "Controls whether to close the tab of the renamed file (Will work only if 'Close On File Delete' setting is disabled)"
-        },
-        "fileutils.move.closeOldTab": {
-          "type": "boolean",
-          "default": true,
-          "description": "Controls whether to close the tab of the moved file (Will work only if 'Close On File Delete' setting is disabled)"
-        },
         "fileutils.typeahead.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/FileItem.ts
+++ b/src/FileItem.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { FileSystemError, Uri, workspace, WorkspaceEdit } from 'vscode';
+import { Uri, workspace, WorkspaceEdit } from 'vscode';
 
 export class FileItem {
 
@@ -51,7 +51,6 @@ export class FileItem {
     public async duplicate(): Promise<FileItem> {
         this.ensureTargetPath();
 
-        const edit = new WorkspaceEdit();
         await workspace.fs.copy(this.path, this.targetPath!, { overwrite: true });
 
         return new FileItem(this.targetPath!);

--- a/src/FileItem.ts
+++ b/src/FileItem.ts
@@ -50,20 +50,17 @@ export class FileItem {
 
     public async duplicate(): Promise<FileItem> {
         this.ensureTargetPath();
+
+        const edit = new WorkspaceEdit();
         await workspace.fs.copy(this.path, this.targetPath!, { overwrite: true });
 
         return new FileItem(this.targetPath!);
     }
 
-    public async remove(useTrash = false): Promise<FileItem> {
-        try {
-            await workspace.fs.delete(this.path, { recursive: true, useTrash });
-        } catch (err) {
-            if (useTrash === true && err instanceof FileSystemError) {
-                return this.remove(false);
-            }
-            throw err;
-        }
+    public async remove(): Promise<FileItem> {
+        const edit = new WorkspaceEdit();
+        edit.deleteFile(this.path, { recursive: true, ignoreIfNotExists: true });
+        await workspace.applyEdit(edit);
         return this;
     }
 

--- a/src/command/MoveFileCommand.ts
+++ b/src/command/MoveFileCommand.ts
@@ -1,7 +1,5 @@
-import { ExtensionContext, Uri } from 'vscode';
-import { IFileController, MoveFileController } from '../controller';
+import { Uri } from 'vscode';
 import { IMoveFileDialogOptions } from '../controller/MoveFileController';
-import { getConfiguration } from '../lib/config';
 import { BaseCommand } from './BaseCommand';
 
 export class MoveFileCommand extends BaseCommand {
@@ -11,12 +9,6 @@ export class MoveFileCommand extends BaseCommand {
         const fileItem = await this.controller.showDialog(dialogOptions);
         if (fileItem) {
             await this.controller.execute({ fileItem });
-
-            if (getConfiguration('move.closeOldTab')) {
-                await this.controller.closeCurrentFileEditor();
-            }
-
-            return this.controller.openFileInEditor(fileItem);
         }
     }
 

--- a/src/command/RenameFileCommand.ts
+++ b/src/command/RenameFileCommand.ts
@@ -1,5 +1,4 @@
 import { Uri } from 'vscode';
-import { getConfiguration } from '../lib/config';
 import { BaseCommand } from './BaseCommand';
 
 export class RenameFileCommand extends BaseCommand {
@@ -8,13 +7,7 @@ export class RenameFileCommand extends BaseCommand {
         const fileItem = await this.controller.showDialog({ prompt: 'New Name' });
 
         if (fileItem) {
-            const movedFileItem = await this.controller.execute({ fileItem });
-
-            if (getConfiguration('rename.closeOldTab')) {
-                await this.controller.closeCurrentFileEditor();
-            }
-
-            return this.controller.openFileInEditor(movedFileItem);
+            await this.controller.execute({ fileItem });
         }
     }
 

--- a/src/controller/RemoveFileController.ts
+++ b/src/controller/RemoveFileController.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
-import { window } from 'vscode';
+import { window, workspace } from 'vscode';
 import { FileItem } from '../FileItem';
-import { getConfiguration } from '../lib/config';
 import { BaseFileController } from './BaseFileController';
 import { IExecuteOptions } from './FileController';
 
@@ -19,7 +18,7 @@ export class RemoveFileController extends BaseFileController {
         }
 
         const message = `Are you sure you want to delete '${path.basename(sourcePath)}'?`;
-        const action = this.useTrash ? 'Move to Trash' : 'Delete';
+        const action = 'Move to Trash';
         const remove = await window.showInformationMessage(message, { modal: true }, action);
         if (remove) {
             return new FileItem(sourcePath);
@@ -29,18 +28,14 @@ export class RemoveFileController extends BaseFileController {
     public async execute(options: IExecuteOptions): Promise<FileItem> {
         const { fileItem } = options;
         try {
-            await fileItem.remove(this.useTrash);
+            await fileItem.remove();
         } catch (e) {
             throw new Error(`Error deleting file '${fileItem.path}'.`);
         }
         return fileItem;
     }
 
-    private get useTrash(): boolean {
-        return getConfiguration('delete.useTrash');
-    }
-
     private get confirmDelete(): boolean {
-        return getConfiguration('delete.confirm');
+        return workspace.getConfiguration('explorer', null).get('confirmDelete') === true;
     }
 }

--- a/test/command/CopyFileNameCommand.test.ts
+++ b/test/command/CopyFileNameCommand.test.ts
@@ -36,7 +36,7 @@ describe('CopyFileNameCommand', () => {
                 await env.clipboard.writeText(clipboardInitialTestData);
             });
 
-            it('ignores the command call and does not change the clipboard data', async () => {
+            it('should ignore the command call and does not change the clipboard data', async () => {
                 try {
                     await subject.execute();
                     expect.fail('must fail');

--- a/test/command/DuplicateFileCommand.test.ts
+++ b/test/command/DuplicateFileCommand.test.ts
@@ -22,11 +22,11 @@ describe('DuplicateFileCommand', () => {
                 helper.restoreShowInputBox();
             });
 
-            helper.protocol.it('prompts for file destination', subject, 'Duplicate As');
-            helper.protocol.it('duplicates current file to destination', subject);
+            helper.protocol.it('should prompt for file destination', subject, 'Duplicate As');
+            helper.protocol.it('should duplicate current file to destination', subject);
             helper.protocol.describe('target file in non existing nested directories', subject);
             helper.protocol.describe('when target destination exists', subject);
-            helper.protocol.it('opens target file as active editor', subject);
+            helper.protocol.it('should open target file as active editor', subject);
         });
 
         helper.protocol.describe('without open text document', subject);
@@ -37,8 +37,8 @@ describe('DuplicateFileCommand', () => {
 
         afterEach(async () => helper.restoreShowInputBox());
 
-        helper.protocol.it('prompts for file destination', subject, 'Duplicate As');
-        helper.protocol.it('duplicates current file to destination', subject, helper.editorFile1);
-        helper.protocol.it('opens target file as active editor', subject, helper.editorFile1);
+        helper.protocol.it('should prompt for file destination', subject, 'Duplicate As');
+        helper.protocol.it('should duplicate current file to destination', subject, helper.editorFile1);
+        helper.protocol.it('should open target file as active editor', subject, helper.editorFile1);
     });
 });

--- a/test/command/MoveFileCommand.test.ts
+++ b/test/command/MoveFileCommand.test.ts
@@ -25,47 +25,9 @@ describe('MoveFileCommand', () => {
                 helper.restoreShowInputBox();
             });
 
-            helper.protocol.it('prompts for file destination', subject, 'New Location');
-            helper.protocol.it('moves current file to destination', subject);
+            helper.protocol.it('should prompt for file destination', subject, 'New Location');
+            helper.protocol.it('should move current file to destination', subject);
             helper.protocol.describe('target file in non existing nested directories', subject);
-            helper.protocol.describe('when target destination exists', subject, {
-                extra() {
-                    describe('configuration', () => {
-                        beforeEach(async () => {
-                            helper.createExecuteCommandStub().withArgs('workbench.action.closeActiveEditor');
-                        });
-
-                        afterEach(async () => {
-                            helper.restoreGetConfiguration();
-                            helper.restoreExecuteCommand();
-                        });
-
-                        describe('move.closeOldTab set to true', () => {
-                            beforeEach(async () => {
-                                helper.createGetConfigurationStub({ 'move.closeOldTab': true });
-                            });
-
-                            it('moves a file and verifies that the tab of the file was closed', async () => {
-                                await subject.execute();
-                                expect(commands.executeCommand).to.have.been.called;
-                            });
-                        });
-
-                        describe('move.closeOldTab set to false', () => {
-                            beforeEach(async () => {
-                                helper.createGetConfigurationStub({ 'move.closeOldTab': false });
-                            });
-
-                            it('moves a file and verifies that the tab of the file was not closed', async () => {
-                                await subject.execute();
-                                expect(commands.executeCommand).to.have.not.been.called;
-                            });
-                        });
-                    });
-                }
-            });
-
-            helper.protocol.it('opens target file as active editor', subject);
         });
 
         helper.protocol.describe('without open text document', subject);
@@ -76,8 +38,7 @@ describe('MoveFileCommand', () => {
 
         afterEach(async () => helper.restoreShowInputBox());
 
-        helper.protocol.it('prompts for file destination', subject, 'New Location');
-        helper.protocol.it('moves current file to destination', subject, helper.editorFile1);
-        helper.protocol.it('opens target file as active editor', subject, helper.editorFile1);
+        helper.protocol.it('should prompt for file destination', subject, 'New Location');
+        helper.protocol.it('should move current file to destination', subject, helper.editorFile1);
     });
 });

--- a/test/command/NewFileCommand.test.ts
+++ b/test/command/NewFileCommand.test.ts
@@ -30,7 +30,7 @@ describe('NewFileCommand', () => {
             helper.restoreShowQuickPick();
         });
 
-        it('prompts for file destination', async () => {
+        it('should prompt for file destination', async () => {
             await subject.execute();
             const prompt = 'File Name';
             const value = path.join(path.dirname(helper.editorFile1.path), path.sep);
@@ -101,7 +101,7 @@ describe('NewFileCommand', () => {
 
         helper.protocol.describe('target file in non existing nested directories', subject);
         helper.protocol.describe('when target destination exists', subject, { overwriteFileContent: '' });
-        helper.protocol.it('opens target file as active editor', subject);
+        helper.protocol.it('should open target file as active editor', subject);
     });
 
     describe('with relativeToRoot set "true"', () => {

--- a/test/command/RenameFileCommand.test.ts
+++ b/test/command/RenameFileCommand.test.ts
@@ -24,7 +24,7 @@ describe('RenameFileCommand', () => {
                 helper.restoreShowInputBox();
             });
 
-            it('prompts for file destination', async () => {
+            it('should prompt for file destination', async () => {
                 await subject.execute();
                 const prompt = 'New Name';
                 const value = path.basename(helper.editorFile1.fsPath);
@@ -32,47 +32,9 @@ describe('RenameFileCommand', () => {
                 expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
             });
 
-            helper.protocol.it('moves current file to destination', subject);
+            helper.protocol.it('should move current file to destination', subject);
             helper.protocol.describe('target file in non existing nested directories', subject);
-            helper.protocol.describe('when target destination exists', subject, {
-                extra() {
-
-                    describe('configuration', () => {
-                        beforeEach(async () => {
-                            helper.createExecuteCommandStub().withArgs('workbench.action.closeActiveEditor');
-                        });
-
-                        afterEach(async () => {
-                            helper.restoreGetConfiguration();
-                            helper.restoreExecuteCommand();
-                        });
-
-                        describe('rename.closeOldTab set to true', () => {
-                            beforeEach(async () => {
-                                helper.createGetConfigurationStub({ 'rename.closeOldTab': true });
-                            });
-
-                            it('renames a file and verifies that the tab of the file was closed', async () => {
-                                await subject.execute();
-                                expect(commands.executeCommand).to.have.been.called;
-                            });
-                        });
-
-                        describe('rename.closeOldTab set to false', () => {
-                            beforeEach(async () => {
-                                helper.createGetConfigurationStub({ 'rename.closeOldTab': false });
-                            });
-
-                            it('renames a file and verifies that the tab of the file was not closed', async () => {
-                                await subject.execute();
-                                expect(commands.executeCommand).to.have.not.been.called;
-                            });
-                        });
-                    });
-                }
-            });
-
-            helper.protocol.it('opens target file as active editor', subject);
+            helper.protocol.it('should open target file as active editor', subject);
         });
 
         describe('with no open text document', () => {
@@ -83,7 +45,7 @@ describe('RenameFileCommand', () => {
 
             afterEach(() => helper.restoreShowInputBox());
 
-            it('ignores the command call', async () => {
+            it('should ignore the command call', async () => {
                 try {
                     await subject.execute();
                     expect.fail('Must fail');

--- a/test/helper/steps/describe.ts
+++ b/test/helper/steps/describe.ts
@@ -19,9 +19,12 @@ export const describe: IStep = {
 
             mocha.beforeEach(async () => createShowInputBoxStub().resolves(path.resolve(targetDir, 'file.rb')));
 
-            mocha.it('creates nested directories', async () => {
-                const textEditor: TextEditor = await subject.execute();
-                const dirname = path.dirname(textEditor.document.fileName);
+            mocha.it('should create nested directories', async () => {
+                await subject.execute();
+                const textEditor = window.activeTextEditor;
+                expect(textEditor);
+
+                const dirname = path.dirname(textEditor!.document.fileName);
                 const directories: string[] = dirname.split(path.sep);
 
                 expect(directories.pop()).to.equal('level-3');
@@ -39,7 +42,7 @@ export const describe: IStep = {
 
             mocha.afterEach(async () => restoreShowInformationMessage());
 
-            mocha.it('asks to overwrite destination file', async () => {
+            mocha.it('should prompt with confirmation dialog to overwrite destination file', async () => {
                 await subject.execute();
                 const message = `File '${targetFile.path}' already exists.`;
                 const action = 'Overwrite';
@@ -48,7 +51,7 @@ export const describe: IStep = {
             });
 
             mocha.describe(`responding with 'Overwrite'`, () => {
-                mocha.it('overwrites the existig file', async () => {
+                mocha.it('should overwrite the existig file', async () => {
                     await subject.execute();
                     const fileContent = await readFile(targetFile);
                     const expectedFileContent = config && 'overwriteFileContent' in config
@@ -61,7 +64,7 @@ export const describe: IStep = {
             mocha.describe(`responding with 'Cancel'`, () => {
                 mocha.beforeEach(async () => createShowInformationMessageStub().resolves(false));
 
-                mocha.it('leaves existing file untouched', async () => {
+                mocha.it('should leave existing file untouched', async () => {
                     try {
                         await subject.execute();
                         expect.fail('must fail');
@@ -86,7 +89,7 @@ export const describe: IStep = {
 
             mocha.afterEach(async () => restoreShowInputBox());
 
-            mocha.it('ignores the command call', async () => {
+            mocha.it('should ignore the command call', async () => {
                 try {
                     await subject.execute();
                     expect.fail('must fail');

--- a/test/helper/steps/it.ts
+++ b/test/helper/steps/it.ts
@@ -5,20 +5,20 @@ import { editorFile1, targetFile } from '../environment';
 import { FuncVoid, IStep } from './types';
 
 export const it: IStep = {
-    'opens target file as active editor'(subject: any, uri?: Uri): FuncVoid {
+    'should open target file as active editor'(subject: any, uri?: Uri): FuncVoid {
         return async () => {
             await subject.execute(uri);
             expect(window.activeTextEditor!.document.fileName).to.equal(targetFile.path);
         };
     },
-    'moves current file to destination'(subject: any, uri?: Uri): FuncVoid {
+    'should move current file to destination'(subject: any, uri?: Uri): FuncVoid {
         return async () => {
             await subject.execute(uri);
             const message = `${targetFile} does not exist`;
             expect(fs.existsSync(targetFile.fsPath), message).to.be.true;
         };
     },
-    'prompts for file destination'(subject: any, prompt: string): FuncVoid {
+    'should prompt for file destination'(subject: any, prompt: string): FuncVoid {
         return async () => {
             await subject.execute(editorFile1);
             const value = editorFile1.path;
@@ -28,4 +28,4 @@ export const it: IStep = {
     }
 };
 
-it['duplicates current file to destination'] = it['moves current file to destination'];
+it['should duplicate current file to destination'] = it['should move current file to destination'];


### PR DESCRIPTION
# Description

This PR replaces `workspace.fs` where possible in favour of `WorkspaceEdit` which handles open tabs and editor groups automatically. 

Fixes #212 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
