### PR TITLE
feat(menus): add file releated commands to tab and editor context

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,33 +86,6 @@ Non-existent folders are created automatically.
 ]
 ```
 
-## Context Menu
-
-```json
-{
-    "explorer/context": [
-        {
-            "command": "fileutils.moveFile",
-            "group": "edit"
-        },
-        {
-            "command": "fileutils.duplicateFile",
-            "group": "edit"
-        }
-    ],
-    "editor/context": [
-        {
-            "command": "fileutils.moveFile",
-            "group": "edit"
-        },
-        {
-            "command": "fileutils.duplicateFile",
-            "group": "edit"
-        }
-    ]
-}
-```
-
 ## Configuration
 
 ```json

--- a/package.json
+++ b/package.json
@@ -117,22 +117,46 @@
       ],
       "editor/context": [
         {
-          "command": "fileutils.moveFile",
-          "group": "1_modification"
-        },
-        {
-          "command": "fileutils.duplicateFile",
-          "group": "1_modification"
+            "command": "fileutils.copyFileName",
+            "group": "1_copypath"
         },
         {
           "command": "fileutils.renameFile",
-          "group": "1_modification"
+          "group": "1_modification@1"
+        },
+        {
+          "command": "fileutils.moveFile",
+          "group": "1_modification@2"
+        },
+        {
+          "command": "fileutils.duplicateFile",
+          "group": "1_modification@3"
+        },
+        {
+          "command": "fileutils.removeFile",
+          "group": "1_modification@4"
         }
       ],
       "editor/title/context": [
         {
           "command": "fileutils.copyFileName",
           "group": "1_copypath"
+        },
+        {
+          "command": "fileutils.renameFile",
+          "group": "1_modification@1"
+        },
+        {
+          "command": "fileutils.moveFile",
+          "group": "1_modification@2"
+        },
+        {
+          "command": "fileutils.duplicateFile",
+          "group": "1_modification@3"
+        },
+        {
+            "command": "fileutils.removeFile",
+            "group": "1_modification@4"
         }
       ]
     },


### PR DESCRIPTION
# Description

This PR adds all file related commands to editor tab and editor context menus.

Fixes #210 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
