### PR TITLE
fix(duplicate): prevent directories to be opened as document

### DIFF
--- a/src/FileItem.ts
+++ b/src/FileItem.ts
@@ -58,7 +58,7 @@ export class FileItem {
 
         await workspace.fs.copy(this.path, this.targetPath, { overwrite: true });
 
-        return new FileItem(this.targetPath);
+        return new FileItem(this.targetPath, undefined, this.isDir);
     }
 
     public async remove(): Promise<FileItem> {
@@ -81,7 +81,7 @@ export class FileItem {
             await workspace.fs.writeFile(this.targetPath, new Uint8Array());
         }
 
-        return new FileItem(this.targetPath);
+        return new FileItem(this.targetPath, undefined, this.isDir);
     }
 
     private toUri(uriOrString: Uri | string): Uri {

--- a/src/command/DuplicateFileCommand.ts
+++ b/src/command/DuplicateFileCommand.ts
@@ -6,6 +6,6 @@ export class DuplicateFileCommand extends BaseCommand<MoveFileController> {
     public async execute(uri?: Uri): Promise<void> {
         const dialogOptions = { prompt: "Duplicate As", showFullPath: true, uri };
         const fileItem = await this.controller.showDialog(dialogOptions);
-        await this.executeController(fileItem, { openFileInEditor: true });
+        await this.executeController(fileItem, { openFileInEditor: !fileItem?.isDir });
     }
 }

--- a/src/controller/MoveFileController.ts
+++ b/src/controller/MoveFileController.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { Uri, window } from "vscode";
+import { FileType, Uri, window, workspace } from "vscode";
 import { FileItem } from "../FileItem";
 import { BaseFileController } from "./BaseFileController";
 import { DialogOptions, ExecuteOptions } from "./FileController";
@@ -27,8 +27,9 @@ export class MoveFileController extends BaseFileController {
         });
 
         if (targetPath) {
+            const isDir = (await workspace.fs.stat(Uri.file(sourcePath))).type === FileType.Directory;
             const realPath = path.resolve(path.dirname(sourcePath), targetPath);
-            return new FileItem(sourcePath, realPath);
+            return new FileItem(sourcePath, realPath, isDir);
         }
     }
 

--- a/test/command/DuplicateFileCommand.test.ts
+++ b/test/command/DuplicateFileCommand.test.ts
@@ -1,6 +1,11 @@
+import { expect } from "chai";
+import * as path from "path";
+import * as fs from "fs";
+import { Uri, window, workspace } from "vscode";
 import { DuplicateFileCommand } from "../../src/command/DuplicateFileCommand";
 import { DuplicateFileController } from "../../src/controller";
 import * as helper from "../helper";
+import { tmpDir } from "../helper";
 
 describe("DuplicateFileCommand", () => {
     const subject = new DuplicateFileCommand(new DuplicateFileController(helper.createExtensionContext()));
@@ -32,12 +37,50 @@ describe("DuplicateFileCommand", () => {
     });
 
     describe("as context menu", () => {
-        beforeEach(async () => helper.createShowInputBoxStub().resolves(helper.targetFile.path));
+        describe("with selected file", () => {
+            beforeEach(async () => helper.createShowInputBoxStub().resolves(helper.targetFile.path));
 
-        afterEach(async () => helper.restoreShowInputBox());
+            afterEach(async () => helper.restoreShowInputBox());
 
-        helper.protocol.it("should prompt for file destination", subject, "Duplicate As");
-        helper.protocol.it("should duplicate current file to destination", subject, helper.editorFile1);
-        helper.protocol.it("should open target file as active editor", subject, helper.editorFile1);
+            helper.protocol.it("should prompt for file destination", subject, "Duplicate As");
+            helper.protocol.it("should duplicate current file to destination", subject, helper.editorFile1);
+            helper.protocol.it("should open target file as active editor", subject, helper.editorFile1);
+        });
+
+        describe("with selected directory", () => {
+            const sourceDirectory = Uri.file(path.resolve(tmpDir.path, "duplicate-source-dir"));
+            const targetDirectory = Uri.file(path.resolve(tmpDir.path, "duplicate-target-dir"));
+
+            beforeEach(async () => {
+                await workspace.fs.createDirectory(sourceDirectory);
+                helper.createShowInputBoxStub().resolves(targetDirectory.path);
+            });
+
+            afterEach(async () => {
+                await workspace.fs.delete(sourceDirectory, { recursive: true, useTrash: false });
+                await workspace.fs.delete(targetDirectory, { recursive: true, useTrash: false });
+                helper.restoreShowInputBox();
+            });
+
+            it("should prompt for file destination", async () => {
+                await subject.execute(sourceDirectory);
+                const value = sourceDirectory.path;
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const valueSelection = [value.length - value.split(path.sep).pop()!.length, value.length];
+                const prompt = "Duplicate As";
+                expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+            });
+
+            it("should duplicate current file to destination", async () => {
+                await subject.execute(sourceDirectory);
+                const message = `${targetDirectory} does not exist`;
+                expect(fs.existsSync(targetDirectory.fsPath), message).to.be.true;
+            });
+
+            it("should not open target file as active editor", async () => {
+                await subject.execute(sourceDirectory);
+                expect(window.activeTextEditor?.document?.fileName).not.to.equal(targetDirectory.path);
+            });
+        });
     });
 });

--- a/test/helper/callbacks.ts
+++ b/test/helper/callbacks.ts
@@ -4,7 +4,7 @@ import { editorFile1, editorFile2, fixtureFile1, fixtureFile2, tmpDir } from "./
 
 export async function beforeEach(): Promise<void> {
     if (existsSync(tmpDir.fsPath)) {
-        await workspace.fs.delete(tmpDir, { recursive: true });
+        await workspace.fs.delete(tmpDir, { recursive: true, useTrash: false });
     }
     await workspace.fs.copy(fixtureFile1, editorFile1, { overwrite: true });
     await workspace.fs.copy(fixtureFile2, editorFile2, { overwrite: true });
@@ -12,6 +12,6 @@ export async function beforeEach(): Promise<void> {
 
 export async function afterEach(): Promise<void> {
     if (existsSync(tmpDir.fsPath)) {
-        await workspace.fs.delete(tmpDir, { recursive: true });
+        await workspace.fs.delete(tmpDir, { recursive: true, useTrash: false });
     }
 }


### PR DESCRIPTION
# Description

Detect if the file to bee duplicated is a directory, if so we now prevent it from being opened as document after duplication.

Fixes #152 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
