### PR TITLE
fix(NewFileController): properly brace expand backslash paths

### DIFF
--- a/src/command/BaseCommand.ts
+++ b/src/command/BaseCommand.ts
@@ -10,7 +10,7 @@ interface ExecuteControllerOptions {
 export abstract class BaseCommand<T extends FileController> implements Command {
     constructor(protected controller: T, readonly options?: CommandConstructorOptions) {}
 
-    public abstract async execute(uri?: Uri): Promise<void>;
+    public abstract execute(uri?: Uri): Promise<void>;
 
     protected async executeController(
         fileItem: FileItem | undefined,

--- a/src/controller/BaseFileController.ts
+++ b/src/controller/BaseFileController.ts
@@ -6,9 +6,9 @@ import { DialogOptions, ExecuteOptions, FileController, GetSourcePathOptions } f
 export abstract class BaseFileController implements FileController {
     constructor(protected context: ExtensionContext) {}
 
-    public abstract async showDialog(options?: DialogOptions): Promise<FileItem | FileItem[] | undefined>;
+    public abstract showDialog(options?: DialogOptions): Promise<FileItem | FileItem[] | undefined>;
 
-    public abstract async execute(options: ExecuteOptions): Promise<FileItem>;
+    public abstract execute(options: ExecuteOptions): Promise<FileItem>;
 
     public async openFileInEditor(fileItem: FileItem): Promise<TextEditor | undefined> {
         if (fileItem.isDir) {

--- a/src/controller/NewFileController.ts
+++ b/src/controller/NewFileController.ts
@@ -28,9 +28,9 @@ export class NewFileController extends BaseFileController {
         });
 
         if (targetPath) {
-            return expand(targetPath).map((filePath) => {
+            return expand(targetPath.replace(/\\/g, "/")).map((filePath) => {
                 const realPath = path.resolve(sourcePath, filePath);
-                const isDir = filePath.endsWith(path.sep);
+                const isDir = filePath.endsWith("/");
                 return new FileItem(sourcePath, realPath, isDir);
             });
         }
@@ -47,7 +47,7 @@ export class NewFileController extends BaseFileController {
     }
 
     public async getSourcePath({ relativeToRoot }: GetSourcePathOptions): Promise<string> {
-        const rootPath = relativeToRoot ? await this.getWorkspaceSourcePath() : await this.getFileSourcePath();
+        const rootPath = await (relativeToRoot ? this.getWorkspaceSourcePath() : this.getFileSourcePath());
 
         if (!rootPath) {
             throw new Error();

--- a/test/command/NewFileCommand.test.ts
+++ b/test/command/NewFileCommand.test.ts
@@ -98,6 +98,19 @@ describe(NewFileCommand.name, () => {
             });
         });
 
+        describe("file path contains dot and backslash path separator", () => {
+            beforeEach(async () => {
+                const fileName = helper.targetFileWithDot.fsPath.replace(/\//g, "\\");
+                helper.createShowInputBoxStub().resolves(fileName);
+            });
+
+            it("should create the file at destination", async () => {
+                await subject.execute();
+                const message = `${helper.targetFileWithDot.path} does not exist`;
+                expect(fs.existsSync(helper.targetFileWithDot.fsPath), message).to.be.true;
+            });
+        });
+
         helper.protocol.describe("with target file in non-existent nested directory", subject);
         helper.protocol.describe("when target destination exists", subject, { overwriteFileContent: "" });
         helper.protocol.it("should open target file as active editor", subject);

--- a/test/helper/environment.ts
+++ b/test/helper/environment.ts
@@ -12,3 +12,4 @@ export const editorFile1 = Uri.file(path.resolve(tmpDir.fsPath, "file-1.rb"));
 export const editorFile2 = Uri.file(path.resolve(tmpDir.fsPath, "file-2.rb"));
 
 export const targetFile = Uri.file(path.resolve(`${editorFile1.fsPath}.tmp`));
+export const targetFileWithDot = Uri.file(path.resolve(tmpDir.fsPath, ".eslintrc.json"));


### PR DESCRIPTION
# Description

The underlaying brace expansion library seems to handle a combination of `\.` in an unexpected way.
Therefore we are now transforming backslash path separators to forward slashes.

Fixes #309 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
