### PR TITLE
fix: prefer uri over current editor

### DIFF
--- a/src/command/RemoveFileCommand.ts
+++ b/src/command/RemoveFileCommand.ts
@@ -1,9 +1,10 @@
+import { Uri } from "vscode";
 import { RemoveFileController } from "../controller";
 import { BaseCommand } from "./BaseCommand";
 
 export class RemoveFileCommand extends BaseCommand<RemoveFileController> {
-    public async execute(): Promise<void> {
-        const fileItem = await this.controller.showDialog();
+    public async execute(uri?: Uri): Promise<void> {
+        const fileItem = await this.controller.showDialog({ uri });
         await this.executeController(fileItem);
     }
 }

--- a/src/command/RenameFileCommand.ts
+++ b/src/command/RenameFileCommand.ts
@@ -1,9 +1,10 @@
+import { Uri } from "vscode";
 import { MoveFileController } from "../controller";
 import { BaseCommand } from "./BaseCommand";
 
 export class RenameFileCommand extends BaseCommand<MoveFileController> {
-    public async execute(): Promise<void> {
-        const dialogOptions = { prompt: "New Name" };
+    public async execute(uri?: Uri): Promise<void> {
+        const dialogOptions = { prompt: "New Name", uri };
         const fileItem = await this.controller.showDialog(dialogOptions);
         await this.executeController(fileItem);
     }

--- a/src/controller/BaseFileController.ts
+++ b/src/controller/BaseFileController.ts
@@ -32,7 +32,10 @@ export abstract class BaseFileController implements FileController {
         return commands.executeCommand("workbench.action.closeActiveEditor");
     }
 
-    public async getSourcePath({ ignoreIfNotExists }: GetSourcePathOptions = {}): Promise<string> {
+    public async getSourcePath({ ignoreIfNotExists, uri }: GetSourcePathOptions = {}): Promise<string> {
+        if (uri?.fsPath) {
+            return uri.fsPath;
+        }
         // Attempting to get the fileName from the activeTextEditor.
         // Works for text files only.
         const activeEditor = window.activeTextEditor;

--- a/src/controller/CopyFileNameController.ts
+++ b/src/controller/CopyFileNameController.ts
@@ -1,16 +1,12 @@
-import { env, Uri } from "vscode";
+import { env } from "vscode";
 import { FileItem } from "../FileItem";
 import { BaseFileController } from "./BaseFileController";
 import { DialogOptions, ExecuteOptions } from "./FileController";
 
-export interface CopyFileNameDialogOptions extends DialogOptions {
-    uri?: Uri;
-}
-
 export class CopyFileNameController extends BaseFileController {
-    public async showDialog(options: CopyFileNameDialogOptions): Promise<FileItem> {
-        const { uri = null } = options;
-        const sourcePath = (uri && uri.fsPath) || (await this.getSourcePath());
+    public async showDialog(options: DialogOptions): Promise<FileItem> {
+        const { uri } = options;
+        const sourcePath = await this.getSourcePath({ uri });
 
         if (!sourcePath) {
             throw new Error();

--- a/src/controller/FileController.ts
+++ b/src/controller/FileController.ts
@@ -1,8 +1,9 @@
-import { TextEditor } from "vscode";
+import { TextEditor, Uri } from "vscode";
 import { FileItem } from "../FileItem";
 
 export interface DialogOptions {
     prompt?: string;
+    uri?: Uri;
 }
 
 export interface ExecuteOptions {
@@ -12,6 +13,7 @@ export interface ExecuteOptions {
 export interface GetSourcePathOptions {
     relativeToRoot?: boolean;
     ignoreIfNotExists?: boolean;
+    uri?: Uri;
 }
 
 export interface FileController {

--- a/src/controller/MoveFileController.ts
+++ b/src/controller/MoveFileController.ts
@@ -6,13 +6,12 @@ import { DialogOptions, ExecuteOptions } from "./FileController";
 
 export interface MoveFileDialogOptions extends DialogOptions {
     showFullPath?: boolean;
-    uri?: Uri;
 }
 
 export class MoveFileController extends BaseFileController {
     public async showDialog(options: MoveFileDialogOptions): Promise<FileItem | undefined> {
-        const { prompt, showFullPath = false, uri = null } = options;
-        const sourcePath = (uri && uri.fsPath) ?? (await this.getSourcePath());
+        const { prompt, showFullPath = false, uri } = options;
+        const sourcePath = await this.getSourcePath({ uri });
 
         if (!sourcePath) {
             throw new Error();

--- a/src/controller/MoveFileController.ts
+++ b/src/controller/MoveFileController.ts
@@ -12,7 +12,7 @@ export interface MoveFileDialogOptions extends DialogOptions {
 export class MoveFileController extends BaseFileController {
     public async showDialog(options: MoveFileDialogOptions): Promise<FileItem | undefined> {
         const { prompt, showFullPath = false, uri = null } = options;
-        const sourcePath = (uri && uri.fsPath) || (await this.getSourcePath());
+        const sourcePath = (uri && uri.fsPath) ?? (await this.getSourcePath());
 
         if (!sourcePath) {
             throw new Error();

--- a/src/controller/NewFileController.ts
+++ b/src/controller/NewFileController.ts
@@ -7,7 +7,7 @@ import { DialogOptions, ExecuteOptions, GetSourcePathOptions } from "./FileContr
 import { TypeAheadController } from "./TypeAheadController";
 import expand from "brace-expansion";
 
-export interface NewFileDialogOptions extends DialogOptions {
+export interface NewFileDialogOptions extends Omit<DialogOptions, "uri"> {
     relativeToRoot?: boolean;
 }
 

--- a/src/controller/RemoveFileController.ts
+++ b/src/controller/RemoveFileController.ts
@@ -1,16 +1,13 @@
 import * as path from "path";
-import { Uri, window, workspace } from "vscode";
+import { window, workspace } from "vscode";
 import { FileItem } from "../FileItem";
 import { BaseFileController } from "./BaseFileController";
 import { DialogOptions, ExecuteOptions } from "./FileController";
 
-export interface RemoveFileDialogOptions extends DialogOptions {
-    uri?: Uri;
-}
 export class RemoveFileController extends BaseFileController {
-    public async showDialog(options: RemoveFileDialogOptions): Promise<FileItem | undefined> {
-        const { uri = null } = options;
-        const sourcePath = (uri && uri.fsPath) ?? (await this.getSourcePath());
+    public async showDialog(options: DialogOptions): Promise<FileItem | undefined> {
+        const { uri } = options;
+        const sourcePath = await this.getSourcePath({ uri });
 
         if (!sourcePath) {
             throw new Error();

--- a/src/controller/RemoveFileController.ts
+++ b/src/controller/RemoveFileController.ts
@@ -1,12 +1,16 @@
 import * as path from "path";
-import { window, workspace } from "vscode";
+import { Uri, window, workspace } from "vscode";
 import { FileItem } from "../FileItem";
 import { BaseFileController } from "./BaseFileController";
-import { ExecuteOptions } from "./FileController";
+import { DialogOptions, ExecuteOptions } from "./FileController";
 
+export interface RemoveFileDialogOptions extends DialogOptions {
+    uri?: Uri;
+}
 export class RemoveFileController extends BaseFileController {
-    public async showDialog(): Promise<FileItem | undefined> {
-        const sourcePath = await this.getSourcePath();
+    public async showDialog(options: RemoveFileDialogOptions): Promise<FileItem | undefined> {
+        const { uri = null } = options;
+        const sourcePath = (uri && uri.fsPath) ?? (await this.getSourcePath());
 
         if (!sourcePath) {
             throw new Error();

--- a/src/controller/TypeAheadController.ts
+++ b/src/controller/TypeAheadController.ts
@@ -6,7 +6,6 @@ import { TreeWalker } from "../lib/TreeWalker";
 async function waitForIOEvents(): Promise<void> {
     return new Promise((resolve) => setImmediate(resolve));
 }
-
 export class TypeAheadController {
     constructor(private cache: Cache, private relativeToRoot: boolean) {}
 

--- a/test/command/RemoveFileCommand.test.ts
+++ b/test/command/RemoveFileCommand.test.ts
@@ -80,6 +80,18 @@ describe(RemoveFileCommand.name, () => {
                     }
                 });
             });
+
+            describe("prefer uri over current editor", () => {
+                beforeEach(async () => {
+                    helper.createGetConfigurationStub({ confirmDelete: false });
+                });
+
+                it("should delete the file without confirmation", async () => {
+                    await subject.execute(helper.editorFile2);
+                    const message = `${helper.editorFile2.path} does not exist`;
+                    expect(fs.existsSync(helper.editorFile2.fsPath), message).to.be.false;
+                });
+            });
         });
 
         describe("without an open text document", () => {

--- a/test/command/RenameFileCommand.test.ts
+++ b/test/command/RenameFileCommand.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import * as path from "path";
-import { window } from "vscode";
+import { Uri, window } from "vscode";
 import { RenameFileCommand } from "../../src/command";
 import { MoveFileController } from "../../src/controller";
 import * as helper from "../helper";
@@ -35,6 +35,21 @@ describe(RenameFileCommand.name, () => {
             helper.protocol.it("should move current file to destination", subject);
             helper.protocol.describe("with target file in non-existent nested directory", subject);
             helper.protocol.it("should open target file as active editor", subject);
+
+            describe("prefer uri over current editor", () => {
+                beforeEach(async () => {
+                    const targetFile = Uri.file(path.resolve(`${helper.editorFile2.fsPath}.tmp`));
+                    helper.createShowInputBoxStub().resolves(targetFile.path);
+                });
+
+                it("should prompt for file destination", async () => {
+                    await subject.execute(helper.editorFile2);
+                    const prompt = "New Name";
+                    const value = path.basename(helper.editorFile2.fsPath);
+                    const valueSelection = [value.length - 9, value.length - 3];
+                    expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+                });
+            });
         });
 
         describe("without an open text document", () => {


### PR DESCRIPTION
# Description

This PR adds support to detect the origin of an event trigger instead of operating on the current open active editor.

Fixes #330 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
