### PR TITLE
Feature add typeahead support to MoveFile and DuplicateFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out
 .idea
 
 *.vsix
+
+tmp

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}", "--folder-uri=/tmp"],
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}", "--folder-uri=${workspaceFolder}/tmp"],
             "outFiles": ["${workspaceFolder}/out/src/**/*.js"],
             "preLaunchTask": "npm: watch"
         },
@@ -25,7 +25,7 @@
                 "--extensionTestsPath=${workspaceFolder}/out/test"
             ],
             "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: tsc:watch"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,17 +4,27 @@
         {
             "type": "npm",
             "script": "watch",
-            "group": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "problemMatcher": "$esbuild-watch",
             "isBackground": true,
             "label": "npm: watch"
         },
         {
             "type": "npm",
-            "script": "build",
-            "group": "build",
-            "problemMatcher": "$esbuild",
-            "label": "npm: build"
+            "script": "tsc:watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "problemMatcher": ["$tsc-watch"],
+            "label": "npm: tsc:watch"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -113,10 +113,25 @@ Non-existent folders are created automatically.
 
 ```json
 {
-    "fileutils.typeahead.enabled": {
+    "fileutils.duplicateFile.typeahead.enabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Controls wheather to show a directory selector for duplicate file command."
+    },
+    "fileutils.moveFile.typeahead.enabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Controls wheather to show a directory selector for move file command."
+    },
+    "fileutils.newFile.typeahead.enabled": {
         "type": "boolean",
         "default": true,
-        "description": "Controls if directory selector should be shown."
+        "description": "Controls wheather to show a directory selector for new file command."
+    },
+    "fileutils.newFolder.typeahead.enabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Controls wheather to show a directory selector for new folder command."
     }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "brace-expansion": "2.0.1",
-                "esbuild": "0.17.4",
                 "fast-glob": "3.2.12"
             },
             "devDependencies": {
@@ -31,6 +30,7 @@
                 "bluebird": "3.7.2",
                 "bluebird-retry": "0.11.0",
                 "chai": "4.3.7",
+                "esbuild": "^0.17.4",
                 "eslint": "8.32.0",
                 "husky": "8.0.3",
                 "mocha": "10.2.0",
@@ -190,6 +190,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -205,6 +206,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -220,6 +222,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -235,6 +238,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -250,6 +254,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -265,6 +270,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
@@ -280,6 +286,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
@@ -295,6 +302,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -310,6 +318,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -325,6 +334,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -340,6 +350,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -355,6 +366,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -370,6 +382,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -385,6 +398,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -400,6 +414,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -415,6 +430,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -430,6 +446,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "netbsd"
@@ -445,6 +462,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "openbsd"
@@ -460,6 +478,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "sunos"
@@ -475,6 +494,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -490,6 +510,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -505,6 +526,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -3004,6 +3026,7 @@
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.4.tgz",
             "integrity": "sha512-zBn9MeCwT7W5F1a3lXClD61ip6vQM+H8Msb0w8zMT4ZKBpDg+rFAraNyWCDelB/2L6M3g6AXHPnsyvjMFnxtFw==",
+            "dev": true,
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"
@@ -10885,132 +10908,154 @@
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.4.tgz",
             "integrity": "sha512-R9GCe2xl2XDSc2XbQB63mFiFXHIVkOP+ltIxICKXqUPrFX97z6Z7vONCLQM1pSOLGqfLrGi3B7nbhxmFY/fomg==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/android-arm64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.4.tgz",
             "integrity": "sha512-91VwDrl4EpxBCiG6h2LZZEkuNvVZYJkv2T9gyLG/mhGG1qrM7i5SwUcg/hlSPnL/4hDT0TFcF35/XMGSn0bemg==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/android-x64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.4.tgz",
             "integrity": "sha512-mGSqhEPL7029XL7QHNPxPs15JVa02hvZvysUcyMP9UXdGFwncl2WU0bqx+Ysgzd+WAbv8rfNa73QveOxAnAM2w==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/darwin-arm64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.4.tgz",
             "integrity": "sha512-tTyJRM9dHvlMPt1KrBFVB5OW1kXOsRNvAPtbzoKazd5RhD5/wKlXk1qR2MpaZRYwf4WDMadt0Pv0GwxB41CVow==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/darwin-x64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.4.tgz",
             "integrity": "sha512-phQuC2Imrb3TjOJwLN8EO50nb2FHe8Ew0OwgZDH1SV6asIPGudnwTQtighDF2EAYlXChLoMJwqjAp4vAaACq6w==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-arm64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.4.tgz",
             "integrity": "sha512-oH6JUZkocgmjzzYaP5juERLpJQSwazdjZrTPgLRmAU2bzJ688x0vfMB/WTv4r58RiecdHvXOPC46VtsMy/mepg==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-x64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.4.tgz",
             "integrity": "sha512-U4iWGn/9TrAfpAdfd56eO0pRxIgb0a8Wj9jClrhT8hvZnOnS4dfMPW7o4fn15D/KqoiVYHRm43jjBaTt3g/2KA==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.4.tgz",
             "integrity": "sha512-S2s9xWTGMTa/fG5EyMGDeL0wrWVgOSQcNddJWgu6rG1NCSXJHs76ZP9AsxjB3f2nZow9fWOyApklIgiTGZKhiw==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.4.tgz",
             "integrity": "sha512-UkGfQvYlwOaeYJzZG4cLV0hCASzQZnKNktRXUo3/BMZvdau40AOz9GzmGA063n1piq6VrFFh43apRDQx8hMP2w==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-ia32": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.4.tgz",
             "integrity": "sha512-3lqFi4VFo/Vwvn77FZXeLd0ctolIJH/uXkH3yNgEk89Eh6D3XXAC9/iTPEzeEpsNE5IqGIsFa5Z0iPeOh25IyA==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-loong64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.4.tgz",
             "integrity": "sha512-HqpWZkVslDHIwdQ9D+gk7NuAulgQvRxF9no54ut/M55KEb3mi7sQS3GwpPJzSyzzP0UkjQVN7/tbk88/CaX4EQ==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-mips64el": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.4.tgz",
             "integrity": "sha512-d/nMCKKh/SVDbqR9ju+b78vOr0tNXtfBjcp5vfHONCCOAL9ad8gN9dC/u+UnH939pz7wO+0u/x9y1MaZcb/lKA==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-ppc64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.4.tgz",
             "integrity": "sha512-lOD9p2dmjZcNiTU+sGe9Nn6G3aYw3k0HBJies1PU0j5IGfp6tdKOQ6mzfACRFCqXjnBuTqK7eTYpwx09O5LLfg==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-riscv64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.4.tgz",
             "integrity": "sha512-mTGnwWwVshAjGsd8rP+K6583cPDgxOunsqqldEYij7T5/ysluMHKqUIT4TJHfrDFadUwrghAL6QjER4FeqQXoA==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-s390x": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.4.tgz",
             "integrity": "sha512-AQYuUGp50XM29/N/dehADxvc2bUqDcoqrVuijop1Wv72SyxT6dDB9wjUxuPZm2HwIM876UoNNBMVd+iX/UTKVQ==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/linux-x64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.4.tgz",
             "integrity": "sha512-+AsFBwKgQuhV2shfGgA9YloxLDVjXgUEWZum7glR5lLmV94IThu/u2JZGxTgjYby6kyXEx8lKOqP5rTEVBR0Rw==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/netbsd-x64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.4.tgz",
             "integrity": "sha512-zD1TKYX9553OiLS/qkXPMlWoELYkH/VkzRYNKEU+GwFiqkq0SuxsKnsCg5UCdxN3cqd+1KZ8SS3R+WG/Hxy2jQ==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/openbsd-x64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.4.tgz",
             "integrity": "sha512-PY1NjEsLRhPEFFg1AV0/4Or/gR+q2dOb9s5rXcPuCjyHRzbt8vnHJl3vYj+641TgWZzTFmSUnZbzs1zwTzjeqw==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/sunos-x64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.4.tgz",
             "integrity": "sha512-B3Z7s8QZQW9tKGleMRXvVmwwLPAUoDCHs4WZ2ElVMWiortLJFowU1NjAhXOKjDgC7o9ByeVcwyOlJ+F2r6ZgmQ==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/win32-arm64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.4.tgz",
             "integrity": "sha512-0HCu8R3mY/H5V7N6kdlsJkvrT591bO/oRZy8ztF1dhgNU5xD5tAh5bKByT1UjTGjp/VVBsl1PDQ3L18SfvtnBQ==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/win32-ia32": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.4.tgz",
             "integrity": "sha512-VUjhVDQycse1gLbe06pC/uaA0M+piQXJpdpNdhg8sPmeIZZqu5xPoGWVCmcsOO2gaM2cywuTYTHkXRozo3/Nkg==",
+            "dev": true,
             "optional": true
         },
         "@esbuild/win32-x64": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.4.tgz",
             "integrity": "sha512-0kLAjs+xN5OjhTt/aUA6t48SfENSCKgGPfExADYTOo/UCn0ivxos9/anUVeSfg+L+2O9xkFxvJXIJfG+Q4sYSg==",
+            "dev": true,
             "optional": true
         },
         "@eslint/eslintrc": {
@@ -12861,6 +12906,7 @@
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.4.tgz",
             "integrity": "sha512-zBn9MeCwT7W5F1a3lXClD61ip6vQM+H8Msb0w8zMT4ZKBpDg+rFAraNyWCDelB/2L6M3g6AXHPnsyvjMFnxtFw==",
+            "dev": true,
             "requires": {
                 "@esbuild/android-arm": "0.17.4",
                 "@esbuild/android-arm64": "0.17.4",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,19 @@
                 "fileutils.typeahead.enabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Controls if directory selector should be shown."
+                    "description": "Controls wheather to show a directory selector for new file and new folder command.",
+                    "markdownDeprecationMessage": "**Deprecated**: Please use `#fileutils.newFile.typeahead.enabled#` or `#fileutils.newFolder.typeahead.enabled#` instead.",
+                    "deprecationMessage": "Deprecated: Please use fileutils.newFile.typeahead.enabled or fileutils.newFolder.typeahead.enabled instead."
+                },
+                "fileutils.newFile.typeahead.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Controls wheather to show a directory selector for new file command."
+                },
+                "fileutils.newFolder.typeahead.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Controls wheather to show a directory selector for new folder command."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -171,6 +171,11 @@
                     "markdownDeprecationMessage": "**Deprecated**: Please use `#fileutils.newFile.typeahead.enabled#` or `#fileutils.newFolder.typeahead.enabled#` instead.",
                     "deprecationMessage": "Deprecated: Please use fileutils.newFile.typeahead.enabled or fileutils.newFolder.typeahead.enabled instead."
                 },
+                "fileutils.duplicateFile.typeahead.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Controls wheather to show a directory selector for duplicate file command."
+                },
                 "fileutils.moveFile.typeahead.enabled": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -174,15 +174,16 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run -S esbuild-base -- --minify",
-        "esbuild-base": "rimraf out && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
-        "build": "npm run -S esbuild-base -- --sourcemap",
-        "watch": "npm run -S esbuild-base -- --sourcemap --watch",
+        "esbuild-base": "npm run clean && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
+        "watch": "scripts/dev-env && npm run -S esbuild-base -- --sourcemap --watch",
+        "tsc:watch": "tsc -watch -p ./",
         "pretest": "tsc -p ./",
         "test": "node ./out/test/runTest.js",
         "lint": "eslint './{src,test}/**/*.ts'",
         "lint:fix": "npm run lint -- --fix",
         "semantic-release": "semantic-release",
-        "prepare": "[ ! -x ./node_modules/.bin/husky ] && exit 0; husky install"
+        "prepare": "[ ! -x ./node_modules/.bin/husky ] && exit 0; husky install",
+        "clean": "rimraf out"
     },
     "devDependencies": {
         "@enter-at/eslint-config-typescript-prettier": "1.6.0",
@@ -202,6 +203,7 @@
         "bluebird": "3.7.2",
         "bluebird-retry": "0.11.0",
         "chai": "4.3.7",
+        "esbuild": "^0.17.4",
         "eslint": "8.32.0",
         "husky": "8.0.3",
         "mocha": "10.2.0",
@@ -214,7 +216,6 @@
     },
     "dependencies": {
         "brace-expansion": "2.0.1",
-        "esbuild": "0.17.4",
         "fast-glob": "3.2.12"
     }
 }

--- a/package.json
+++ b/package.json
@@ -171,6 +171,11 @@
                     "markdownDeprecationMessage": "**Deprecated**: Please use `#fileutils.newFile.typeahead.enabled#` or `#fileutils.newFolder.typeahead.enabled#` instead.",
                     "deprecationMessage": "Deprecated: Please use fileutils.newFile.typeahead.enabled or fileutils.newFolder.typeahead.enabled instead."
                 },
+                "fileutils.moveFile.typeahead.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Controls wheather to show a directory selector for move file command."
+                },
                 "fileutils.newFile.typeahead.enabled": {
                     "type": "boolean",
                     "default": true,

--- a/scripts/dev-env
+++ b/scripts/dev-env
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+rm -rf ./tmp
+mkdir -p ./tmp/{app,workspace,scripts}
+touch ./tmp/{app,workspace,scripts}/{foo,bar,baz}.ts

--- a/src/command/DuplicateFileCommand.ts
+++ b/src/command/DuplicateFileCommand.ts
@@ -1,10 +1,12 @@
 import { Uri } from "vscode";
 import { MoveFileController } from "../controller/MoveFileController";
+import { getConfiguration } from "../lib/config";
 import { BaseCommand } from "./BaseCommand";
 
 export class DuplicateFileCommand extends BaseCommand<MoveFileController> {
     public async execute(uri?: Uri): Promise<void> {
-        const dialogOptions = { prompt: "Duplicate As", showFullPath: true, uri };
+        const typeahead = getConfiguration("duplicateFile.typeahead.enabled") === true;
+        const dialogOptions = { prompt: "Duplicate As", showFullPath: true, uri, typeahead };
         const fileItem = await this.controller.showDialog(dialogOptions);
         await this.executeController(fileItem, { openFileInEditor: !fileItem?.isDir });
     }

--- a/src/command/MoveFileCommand.ts
+++ b/src/command/MoveFileCommand.ts
@@ -1,10 +1,12 @@
 import { Uri } from "vscode";
 import { MoveFileController } from "../controller/MoveFileController";
+import { getConfiguration } from "../lib/config";
 import { BaseCommand } from "./BaseCommand";
 
 export class MoveFileCommand extends BaseCommand<MoveFileController> {
     public async execute(uri?: Uri): Promise<void> {
-        const dialogOptions = { prompt: "New Location", showFullPath: true, uri };
+        const typeahead = getConfiguration("moveFile.typeahead.enabled") === true;
+        const dialogOptions = { prompt: "New Location", showFullPath: true, uri, typeahead };
         const fileItem = await this.controller.showDialog(dialogOptions);
         await this.executeController(fileItem);
     }

--- a/src/command/NewFileCommand.ts
+++ b/src/command/NewFileCommand.ts
@@ -1,10 +1,12 @@
 import { NewFileController } from "../controller/NewFileController";
+import { getConfiguration } from "../lib/config";
 import { BaseCommand } from "./BaseCommand";
 
 export class NewFileCommand extends BaseCommand<NewFileController> {
     public async execute(): Promise<void> {
+        const typeahead = this.typeahead;
         const relativeToRoot = this.options?.relativeToRoot ?? false;
-        const dialogOptions = { prompt: "File Name", relativeToRoot };
+        const dialogOptions = { prompt: "File Name", relativeToRoot, typeahead };
         const fileItems = await this.controller.showDialog(dialogOptions);
 
         if (fileItems) {
@@ -14,5 +16,9 @@ export class NewFileCommand extends BaseCommand<NewFileController> {
             });
             await Promise.all(executions);
         }
+    }
+
+    protected get typeahead(): boolean {
+        return (getConfiguration("newFile.typeahead.enabled") ?? getConfiguration("typeahead.enabled")) === true;
     }
 }

--- a/src/command/NewFolderCommand.ts
+++ b/src/command/NewFolderCommand.ts
@@ -1,9 +1,11 @@
+import { getConfiguration } from "../lib/config";
 import { NewFileCommand } from "./NewFileCommand";
 
 export class NewFolderCommand extends NewFileCommand {
     public async execute(): Promise<void> {
+        const typeahead = this.typeahead;
         const relativeToRoot = this.options?.relativeToRoot ?? false;
-        const dialogOptions = { prompt: "Folder Name", relativeToRoot };
+        const dialogOptions = { prompt: "Folder Name", relativeToRoot, typeahead };
         const fileItems = await this.controller.showDialog(dialogOptions);
 
         if (fileItems) {
@@ -12,5 +14,9 @@ export class NewFolderCommand extends NewFileCommand {
             });
             await Promise.all(executions);
         }
+    }
+
+    protected get typeahead(): boolean {
+        return (getConfiguration("newFolder.typeahead.enabled") ?? getConfiguration("typeahead.enabled")) === true;
     }
 }

--- a/src/controller/FileController.ts
+++ b/src/controller/FileController.ts
@@ -4,6 +4,7 @@ import { FileItem } from "../FileItem";
 export interface DialogOptions {
     prompt?: string;
     uri?: Uri;
+    typeahead?: boolean;
 }
 
 export interface ExecuteOptions {
@@ -14,6 +15,7 @@ export interface GetSourcePathOptions {
     relativeToRoot?: boolean;
     ignoreIfNotExists?: boolean;
     uri?: Uri;
+    typeahead?: boolean;
 }
 
 export interface FileController {

--- a/src/controller/TypeAheadController.ts
+++ b/src/controller/TypeAheadController.ts
@@ -7,7 +7,7 @@ async function waitForIOEvents(): Promise<void> {
     return new Promise((resolve) => setImmediate(resolve));
 }
 export class TypeAheadController {
-    constructor(private cache: Cache, private relativeToRoot: boolean) {}
+    constructor(private cache: Cache, private relativeToRoot: boolean = false) {}
 
     public async showDialog(sourcePath: string): Promise<string> {
         const items = await this.buildQuickPickItems(sourcePath);

--- a/test/command/DuplicateFileCommand.test.ts
+++ b/test/command/DuplicateFileCommand.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
-import * as path from "path";
 import * as fs from "fs";
+import * as path from "path";
+import sinon from "sinon";
 import { Uri, window, workspace } from "vscode";
 import { DuplicateFileCommand } from "../../src/command/DuplicateFileCommand";
 import { DuplicateFileController } from "../../src/controller";
@@ -10,7 +11,10 @@ import { tmpDir } from "../helper";
 describe(DuplicateFileCommand.name, () => {
     const subject = new DuplicateFileCommand(new DuplicateFileController(helper.createExtensionContext()));
 
-    beforeEach(helper.beforeEach);
+    beforeEach(async () => {
+        await helper.beforeEach();
+        helper.createGetConfigurationStub({ "duplicateFile.typeahead.enabled": false });
+    });
 
     afterEach(helper.afterEach);
 
@@ -19,11 +23,13 @@ describe(DuplicateFileCommand.name, () => {
             beforeEach(async () => {
                 await helper.openDocument(helper.editorFile1);
                 helper.createShowInputBoxStub().resolves(helper.targetFile.path);
+                helper.createShowQuickPickStub().resolves({ label: "/", description: "" });
             });
 
             afterEach(async () => {
                 await helper.closeAllEditors();
                 helper.restoreShowInputBox();
+                helper.restoreShowQuickPick();
             });
 
             helper.protocol.it("should prompt for file destination", subject, "Duplicate As");
@@ -31,6 +37,45 @@ describe(DuplicateFileCommand.name, () => {
             helper.protocol.describe("with target file in non-existent nested directory", subject);
             helper.protocol.describe("when target destination exists", subject);
             helper.protocol.it("should open target file as active editor", subject);
+
+            describe("configuration", () => {
+                describe('when "newFile.typeahead.enabled" is "true"', () => {
+                    beforeEach(async () => {
+                        await workspace.fs.createDirectory(Uri.file(path.resolve(helper.tmpDir.fsPath, "dir-1")));
+                        await workspace.fs.createDirectory(Uri.file(path.resolve(helper.tmpDir.fsPath, "dir-2")));
+
+                        helper.createGetConfigurationStub({ "duplicateFile.typeahead.enabled": true });
+                        helper
+                            .createStubObject(workspace, "workspaceFolders")
+                            .get(() => [{ uri: Uri.file(helper.tmpDir.fsPath), name: "a", index: 0 }]);
+                    });
+
+                    it("should show the quick pick dialog", async () => {
+                        await subject.execute();
+                        expect(window.showQuickPick).to.have.been.calledOnceWith(
+                            sinon.match([
+                                { description: "- workspace root", label: "/" },
+                                { description: undefined, label: "/dir-1" },
+                                { description: undefined, label: "/dir-2" },
+                            ]),
+                            sinon.match({
+                                placeHolder: helper.quickPick.typeahead.placeHolder,
+                            })
+                        );
+                    });
+                });
+
+                describe('when "newFile.typeahead.enabled" is "false"', () => {
+                    beforeEach(async () => {
+                        helper.createGetConfigurationStub({ "duplicateFile.typeahead.enabled": false });
+                    });
+
+                    it("should not show the quick pick dialog", async () => {
+                        await subject.execute();
+                        expect(window.showQuickPick).to.have.not.been.called;
+                    });
+                });
+            });
         });
 
         helper.protocol.describe("without an open text document", subject);
@@ -65,8 +110,7 @@ describe(DuplicateFileCommand.name, () => {
             it("should prompt for file destination", async () => {
                 await subject.execute(sourceDirectory);
                 const value = sourceDirectory.path;
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                const valueSelection = [value.length - value.split(path.sep).pop()!.length, value.length];
+                const valueSelection = [value.length - (value.split(path.sep).pop() as string).length, value.length];
                 const prompt = "Duplicate As";
                 expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
             });

--- a/test/command/MoveFileCommand.test.ts
+++ b/test/command/MoveFileCommand.test.ts
@@ -1,3 +1,7 @@
+import { expect } from "chai";
+import path from "path";
+import sinon from "sinon";
+import { Uri, window, workspace } from "vscode";
 import { MoveFileCommand } from "../../src/command";
 import { MoveFileController } from "../../src/controller";
 import * as helper from "../helper";
@@ -5,7 +9,10 @@ import * as helper from "../helper";
 describe(MoveFileCommand.name, () => {
     const subject = new MoveFileCommand(new MoveFileController(helper.createExtensionContext()));
 
-    beforeEach(helper.beforeEach);
+    beforeEach(async () => {
+        await helper.beforeEach();
+        helper.createGetConfigurationStub({ "moveFile.typeahead.enabled": false });
+    });
 
     afterEach(helper.afterEach);
 
@@ -14,16 +21,57 @@ describe(MoveFileCommand.name, () => {
             beforeEach(async () => {
                 await helper.openDocument(helper.editorFile1);
                 helper.createShowInputBoxStub().resolves(helper.targetFile.path);
+                helper.createShowQuickPickStub().resolves({ label: "/", description: "" });
             });
 
             afterEach(async () => {
                 await helper.closeAllEditors();
                 helper.restoreShowInputBox();
+                helper.restoreShowQuickPick();
             });
 
             helper.protocol.it("should prompt for file destination", subject, "New Location");
             helper.protocol.it("should move current file to destination", subject);
             helper.protocol.describe("with target file in non-existent nested directory", subject);
+
+            describe("configuration", () => {
+                describe('when "newFile.typeahead.enabled" is "true"', () => {
+                    beforeEach(async () => {
+                        await workspace.fs.createDirectory(Uri.file(path.resolve(helper.tmpDir.fsPath, "dir-1")));
+                        await workspace.fs.createDirectory(Uri.file(path.resolve(helper.tmpDir.fsPath, "dir-2")));
+
+                        helper.createGetConfigurationStub({ "moveFile.typeahead.enabled": true });
+                        helper
+                            .createStubObject(workspace, "workspaceFolders")
+                            .get(() => [{ uri: Uri.file(helper.tmpDir.fsPath), name: "a", index: 0 }]);
+                    });
+
+                    it("should show the quick pick dialog", async () => {
+                        await subject.execute();
+                        expect(window.showQuickPick).to.have.been.calledOnceWith(
+                            sinon.match([
+                                { description: "- workspace root", label: "/" },
+                                { description: undefined, label: "/dir-1" },
+                                { description: undefined, label: "/dir-2" },
+                            ]),
+                            sinon.match({
+                                placeHolder: helper.quickPick.typeahead.placeHolder,
+                            })
+                        );
+                    });
+                });
+
+                describe('when "newFile.typeahead.enabled" is "false"', () => {
+                    beforeEach(async () => {
+                        helper.createGetConfigurationStub({ "moveFile.typeahead.enabled": false });
+                    });
+
+                    it("should not show the quick pick dialog", async () => {
+                        await subject.execute();
+                        expect(window.showQuickPick).to.have.not.been.called;
+                    });
+                });
+            });
         });
 
         helper.protocol.describe("without an open text document", subject);

--- a/test/command/NewFileCommand.test.ts
+++ b/test/command/NewFileCommand.test.ts
@@ -8,10 +8,10 @@ import { NewFileController } from "../../src/controller";
 import * as helper from "../helper";
 
 describe(NewFileCommand.name, () => {
-    const hint = "larger projects may take a moment to load";
-    const expectedShowQuickPickPlaceHolder = `First, select an existing path to create relative to (${hint})`;
-
-    beforeEach(helper.beforeEach);
+    beforeEach(async () => {
+        await helper.beforeEach();
+        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": false });
+    });
 
     afterEach(helper.afterEach);
 
@@ -44,13 +44,9 @@ describe(NewFileCommand.name, () => {
                 await workspace.fs.createDirectory(Uri.file(path.resolve(helper.tmpDir.fsPath, "dir-2")));
             });
 
-            afterEach(async () => {
-                helper.restoreGetConfiguration();
-            });
-
-            describe('"typeahead.enabled" is "true"', () => {
+            describe('"newFile.typeahead.enabled" is "true"', () => {
                 beforeEach(async () => {
-                    helper.createGetConfigurationStub({ "typeahead.enabled": true });
+                    helper.createGetConfigurationStub({ "newFile.typeahead.enabled": true });
                 });
 
                 it("should show the quick pick dialog", async () => {
@@ -62,18 +58,18 @@ describe(NewFileCommand.name, () => {
                             { description: undefined, label: "/dir-2" },
                         ]),
                         sinon.match({
-                            placeHolder: expectedShowQuickPickPlaceHolder,
+                            placeHolder: helper.quickPick.typeahead.placeHolder,
                         })
                     );
                 });
             });
 
-            describe('"typeahead.enabled" is "false"', () => {
+            describe('"newFile.typeahead.enabled" is "false"', () => {
                 beforeEach(async () => {
-                    helper.createGetConfigurationStub({ "typeahead.enabled": false });
+                    helper.createGetConfigurationStub({ "newFile.typeahead.enabled": false });
                 });
 
-                it("should show the quick pick dialog", async () => {
+                it("should not show the quick pick dialog", async () => {
                     await subject.execute();
                     expect(window.showQuickPick).to.have.not.been.called;
                 });
@@ -185,9 +181,9 @@ describe(NewFileCommand.name, () => {
                     helper.restoreGetConfiguration();
                 });
 
-                describe('when "typeahead.enabled" is "true"', () => {
+                describe('when "newFile.typeahead.enabled" is "true"', () => {
                     beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "typeahead.enabled": true });
+                        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": true });
                     });
 
                     it("should show the quick pick dialog", async () => {
@@ -199,18 +195,18 @@ describe(NewFileCommand.name, () => {
                                 { description: undefined, label: "/dir-2" },
                             ]),
                             sinon.match({
-                                placeHolder: expectedShowQuickPickPlaceHolder,
+                                placeHolder: helper.quickPick.typeahead.placeHolder,
                             })
                         );
                     });
                 });
 
-                describe('when "typeahead.enabled" is "false"', () => {
+                describe('when "newFile.typeahead.enabled" is "false"', () => {
                     beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "typeahead.enabled": false });
+                        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": false });
                     });
 
-                    it("should show the quick pick dialog", async () => {
+                    it("should not show the quick pick dialog", async () => {
                         await subject.execute();
                         expect(window.showQuickPick).to.have.not.been.called;
                     });
@@ -267,9 +263,9 @@ describe(NewFileCommand.name, () => {
                     helper.restoreGetConfiguration();
                 });
 
-                describe('when "typeahead.enabled" is "true"', () => {
+                describe('when "newFile.typeahead.enabled" is "true"', () => {
                     beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "typeahead.enabled": true });
+                        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": true });
                     });
 
                     it("should show the quick pick dialog", async () => {
@@ -282,15 +278,15 @@ describe(NewFileCommand.name, () => {
                                 { description: undefined, label: "/dir-2" },
                             ]),
                             sinon.match({
-                                placeHolder: expectedShowQuickPickPlaceHolder,
+                                placeHolder: helper.quickPick.typeahead.placeHolder,
                             })
                         );
                     });
                 });
 
-                describe('when "typeahead.enabled" is "false"', () => {
+                describe('when "newFile.typeahead.enabled" is "false"', () => {
                     beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "typeahead.enabled": false });
+                        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": false });
                     });
 
                     it("should not show the quick pick dialog", async () => {

--- a/test/helper/callbacks.ts
+++ b/test/helper/callbacks.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "fs";
 import { workspace } from "vscode";
 import { editorFile1, editorFile2, fixtureFile1, fixtureFile2, tmpDir } from "./environment";
+import { restoreGetConfiguration } from "./stubs";
 
 export async function beforeEach(): Promise<void> {
     if (existsSync(tmpDir.fsPath)) {
@@ -14,4 +15,5 @@ export async function afterEach(): Promise<void> {
     if (existsSync(tmpDir.fsPath)) {
         await workspace.fs.delete(tmpDir, { recursive: true, useTrash: false });
     }
+    restoreGetConfiguration();
 }

--- a/test/helper/index.ts
+++ b/test/helper/index.ts
@@ -22,3 +22,9 @@ export const protocol = {
         return mocha.it(name, step);
     },
 };
+
+export const quickPick = {
+    typeahead: {
+        placeHolder: "First, select an existing path to create relative to (larger projects may take a moment to load)",
+    },
+};


### PR DESCRIPTION
# Description

Add typeahead support for both the `MoveFile` and `DuplicateFile` command.
In order to provide better control where typeahead should be enabled, a dedicated configuration setting per command has beed introduced. 

Fixes  #486

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
