### PR TITLE
Add support to configure the input box path representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,22 +116,38 @@ Non-existent folders are created automatically.
     "fileutils.duplicateFile.typeahead.enabled": {
         "type": "boolean",
         "default": false,
-        "description": "Controls wheather to show a directory selector for duplicate file command."
+        "description": "Controls whether to show a directory selector for the duplicate file command."
     },
     "fileutils.moveFile.typeahead.enabled": {
         "type": "boolean",
         "default": false,
-        "description": "Controls wheather to show a directory selector for move file command."
+        "description": "Controls whether to show a directory selector for the move file command."
     },
     "fileutils.newFile.typeahead.enabled": {
         "type": "boolean",
         "default": true,
-        "description": "Controls wheather to show a directory selector for new file command."
+        "description": "Controls whether to show a directory selector for the new file command."
     },
     "fileutils.newFolder.typeahead.enabled": {
         "type": "boolean",
         "default": true,
-        "description": "Controls wheather to show a directory selector for new folder command."
+        "description": "Controls whether to show a directory selector for new folder command."
+    },
+    "fileutils.inputBox.pathType": {
+        "type": "string",
+        "default": "root",
+        "enum": ["root", "workspace"],
+        "enumDescriptions": [
+            "Absolute file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace)",
+            "Relative file path of the opened workspace or folder (e.g. /myWorkspace)"
+        ],
+        "description": "Controls the path that is shown in the input box."
+    },
+    "fileutils.inputBox.pathTypeIndicator": {
+        "type": "string",
+        "default": "@",
+        "maxLength": 50,
+        "description": "Controls the indicator that is shown in the input box when the path type is workspace. This setting only has an effect when 'fileutils.inputBox.pathType' is set to 'workspace'."
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
         },
         "configuration": {
             "type": "object",
-            "title": "Fileutils",
+            "title": "File Utils",
             "properties": {
                 "fileutils.typeahead.enabled": {
                     "type": "boolean",
@@ -191,7 +191,7 @@
                     "default": true,
                     "description": "Controls whether to show a directory selector for new folder command."
                 },
-                "fileutils.inputBox.path": {
+                "fileutils.inputBox.pathType": {
                     "type": "string",
                     "default": "root",
                     "enum": [
@@ -203,6 +203,13 @@
                         "Relative file path of the opened workspace or folder (e.g. /myWorkspace)"
                     ],
                     "description": "Controls the path that is shown in the input box."
+                },
+                "fileutils.inputBox.pathTypeIndicator": {
+                    "type": "string",
+                    "default": "@",
+                    "maxLength": 50,
+                    "description": "Controls the indicator that is shown in the input box when the path type is workspace. This setting only has an effect when 'fileutils.inputBox.pathType' is set to 'workspace'.",
+                    "markdownDescription": "Controls the indicator that is shown in the input box when the path type is workspace. \n\nThis setting only has an effect when `#fileutils.inputBox.pathType#` is set to `workspace`.\n\nFor example, if the path type is `workspace` and the indicator is `@`, the path will be shown as `@/myWorkspace`."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -162,34 +162,47 @@
         },
         "configuration": {
             "type": "object",
-            "title": "Fileutils configuration",
+            "title": "Fileutils",
             "properties": {
                 "fileutils.typeahead.enabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Controls wheather to show a directory selector for new file and new folder command.",
+                    "description": "Controls whether to show a directory selector for new file and new folder command.",
                     "markdownDeprecationMessage": "**Deprecated**: Please use `#fileutils.newFile.typeahead.enabled#` or `#fileutils.newFolder.typeahead.enabled#` instead.",
                     "deprecationMessage": "Deprecated: Please use fileutils.newFile.typeahead.enabled or fileutils.newFolder.typeahead.enabled instead."
                 },
                 "fileutils.duplicateFile.typeahead.enabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Controls wheather to show a directory selector for duplicate file command."
+                    "description": "Controls whether to show a directory selector for the duplicate file command."
                 },
                 "fileutils.moveFile.typeahead.enabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Controls wheather to show a directory selector for move file command."
+                    "description": "Controls whether to show a directory selector for the move file command."
                 },
                 "fileutils.newFile.typeahead.enabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Controls wheather to show a directory selector for new file command."
+                    "description": "Controls whether to show a directory selector for the new file command."
                 },
                 "fileutils.newFolder.typeahead.enabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Controls wheather to show a directory selector for new folder command."
+                    "description": "Controls whether to show a directory selector for new folder command."
+                },
+                "fileutils.inputBox.path": {
+                    "type": "string",
+                    "default": "root",
+                    "enum": [
+                        "root",
+                        "workspace"
+                    ],
+                    "enumDescriptions": [
+                        "Absolute file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace)",
+                        "Relative file path of the opened workspace or folder (e.g. /myWorkspace)"
+                    ],
+                    "description": "Controls the path that is shown in the input box."
                 }
             }
         }

--- a/src/command/DuplicateFileCommand.ts
+++ b/src/command/DuplicateFileCommand.ts
@@ -6,7 +6,7 @@ import { BaseCommand } from "./BaseCommand";
 export class DuplicateFileCommand extends BaseCommand<MoveFileController> {
     public async execute(uri?: Uri): Promise<void> {
         const typeahead = getConfiguration("duplicateFile.typeahead.enabled") === true;
-        const dialogOptions = { prompt: "Duplicate As", showFullPath: true, uri, typeahead };
+        const dialogOptions = { prompt: "Duplicate As", showPath: true, uri, typeahead };
         const fileItem = await this.controller.showDialog(dialogOptions);
         await this.executeController(fileItem, { openFileInEditor: !fileItem?.isDir });
     }

--- a/src/command/DuplicateFileCommand.ts
+++ b/src/command/DuplicateFileCommand.ts
@@ -6,7 +6,7 @@ import { BaseCommand } from "./BaseCommand";
 export class DuplicateFileCommand extends BaseCommand<MoveFileController> {
     public async execute(uri?: Uri): Promise<void> {
         const typeahead = getConfiguration("duplicateFile.typeahead.enabled") === true;
-        const dialogOptions = { prompt: "Duplicate As", showPath: true, uri, typeahead };
+        const dialogOptions = { prompt: "Duplicate As", uri, typeahead };
         const fileItem = await this.controller.showDialog(dialogOptions);
         await this.executeController(fileItem, { openFileInEditor: !fileItem?.isDir });
     }

--- a/src/command/MoveFileCommand.ts
+++ b/src/command/MoveFileCommand.ts
@@ -6,7 +6,7 @@ import { BaseCommand } from "./BaseCommand";
 export class MoveFileCommand extends BaseCommand<MoveFileController> {
     public async execute(uri?: Uri): Promise<void> {
         const typeahead = getConfiguration("moveFile.typeahead.enabled") === true;
-        const dialogOptions = { prompt: "New Location", showFullPath: true, uri, typeahead };
+        const dialogOptions = { prompt: "New Location", showPath: true, uri, typeahead };
         const fileItem = await this.controller.showDialog(dialogOptions);
         await this.executeController(fileItem);
     }

--- a/src/command/MoveFileCommand.ts
+++ b/src/command/MoveFileCommand.ts
@@ -6,7 +6,7 @@ import { BaseCommand } from "./BaseCommand";
 export class MoveFileCommand extends BaseCommand<MoveFileController> {
     public async execute(uri?: Uri): Promise<void> {
         const typeahead = getConfiguration("moveFile.typeahead.enabled") === true;
-        const dialogOptions = { prompt: "New Location", showPath: true, uri, typeahead };
+        const dialogOptions = { prompt: "New Location", uri, typeahead };
         const fileItem = await this.controller.showDialog(dialogOptions);
         await this.executeController(fileItem);
     }

--- a/src/command/RenameFileCommand.ts
+++ b/src/command/RenameFileCommand.ts
@@ -1,8 +1,8 @@
 import { Uri } from "vscode";
-import { MoveFileController } from "../controller";
+import { RenameFileController } from "../controller/RenameFileController";
 import { BaseCommand } from "./BaseCommand";
 
-export class RenameFileCommand extends BaseCommand<MoveFileController> {
+export class RenameFileCommand extends BaseCommand<RenameFileController> {
     public async execute(uri?: Uri): Promise<void> {
         const dialogOptions = { prompt: "New Name", uri };
         const fileItem = await this.controller.showDialog(dialogOptions);

--- a/src/controller/BaseFileController.ts
+++ b/src/controller/BaseFileController.ts
@@ -1,5 +1,15 @@
 import path from "path";
-import { commands, env, ExtensionContext, TextEditor, Uri, window, workspace, WorkspaceFolder } from "vscode";
+import {
+    commands,
+    env,
+    ExtensionContext,
+    InputBoxOptions,
+    TextEditor,
+    Uri,
+    window,
+    workspace,
+    WorkspaceFolder,
+} from "vscode";
 import { FileItem } from "../FileItem";
 import { Cache } from "../lib/Cache";
 import { getConfiguration } from "../lib/config";
@@ -7,6 +17,8 @@ import { DialogOptions, ExecuteOptions, FileController, GetSourcePathOptions } f
 import { TypeAheadController } from "./TypeAheadController";
 
 type InputBoxPathType = "root" | "workspace";
+
+type TargetPathInputBoxOptions = InputBoxOptions & Required<Pick<InputBoxOptions, "value">>;
 
 export interface GetTargetPathInputBoxValueOptions extends DialogOptions {
     workspaceFolderPath?: string;
@@ -52,12 +64,10 @@ export abstract class BaseFileController implements FileController {
             workspaceFolderPath,
             pathType,
         });
-        const valueSelection = this.getFilenameSelection(value);
 
-        const targetPath = await window.showInputBox({
+        const targetPath = await this.showTargetPathInputBox({
             prompt,
             value,
-            valueSelection,
         });
 
         const shouldPrependWorkspaceFolderPath = targetPath && workspaceFolderPath && pathType === "workspace";
@@ -66,6 +76,17 @@ export abstract class BaseFileController implements FileController {
         }
 
         return targetPath;
+    }
+
+    protected async showTargetPathInputBox(options: TargetPathInputBoxOptions): Promise<string | undefined> {
+        const { prompt, value } = options;
+        const valueSelection = this.getFilenameSelection(value);
+
+        return await window.showInputBox({
+            prompt,
+            value,
+            valueSelection,
+        });
     }
 
     private getInputBoxPathType(): InputBoxPathType {

--- a/src/controller/BaseFileController.ts
+++ b/src/controller/BaseFileController.ts
@@ -60,7 +60,8 @@ export abstract class BaseFileController implements FileController {
             valueSelection,
         });
 
-        if (targetPath && workspaceFolderPath) {
+        const shouldPrependWorkspaceFolderPath = targetPath && workspaceFolderPath && pathType === "workspace";
+        if (shouldPrependWorkspaceFolderPath) {
             return path.join(workspaceFolderPath, targetPath.replace(workspaceFolderPath, ""));
         }
 

--- a/src/controller/BaseFileController.ts
+++ b/src/controller/BaseFileController.ts
@@ -6,11 +6,11 @@ import { getConfiguration } from "../lib/config";
 import { DialogOptions, ExecuteOptions, FileController, GetSourcePathOptions } from "./FileController";
 import { TypeAheadController } from "./TypeAheadController";
 
-type PromptPathType = "root" | "workspace";
+type InputBoxPathType = "root" | "workspace";
 
-export interface GetTargetPathPromptValueOptions extends DialogOptions {
+export interface GetTargetPathInputBoxValueOptions extends DialogOptions {
     workspaceFolderPath?: string;
-    pathType: PromptPathType;
+    pathType: InputBoxPathType;
 }
 
 export abstract class BaseFileController implements FileController {
@@ -45,29 +45,29 @@ export abstract class BaseFileController implements FileController {
     protected async getTargetPath(sourcePath: string, options: DialogOptions): Promise<string | undefined> {
         const { prompt } = options;
 
-        const pathType = this.getPromptPathType();
+        const pathType = this.getInputBoxPathType();
         const workspaceFolderPath = await this.getWorkspaceFolderPath();
-        const value = await this.getTargetPathPromptValue(sourcePath, {
+        const value = await this.getTargetPathInputBoxValue(sourcePath, {
             ...options,
             workspaceFolderPath,
             pathType,
         });
         const valueSelection = this.getFilenameSelection(value);
 
-        const response = await window.showInputBox({
+        const targetPath = await window.showInputBox({
             prompt,
             value,
             valueSelection,
         });
 
-        if (response && workspaceFolderPath) {
-            return path.join(workspaceFolderPath, response.replace(workspaceFolderPath, ""));
+        if (targetPath && workspaceFolderPath) {
+            return path.join(workspaceFolderPath, targetPath.replace(workspaceFolderPath, ""));
         }
 
-        return response;
+        return targetPath;
     }
 
-    private getPromptPathType(): PromptPathType {
+    private getInputBoxPathType(): InputBoxPathType {
         const pathType = getConfiguration("inputBox.path");
 
         if (pathType === "workspace" || pathType === "root") {
@@ -76,9 +76,9 @@ export abstract class BaseFileController implements FileController {
         return "root";
     }
 
-    protected async getTargetPathPromptValue(
+    protected async getTargetPathInputBoxValue(
         sourcePath: string,
-        options: GetTargetPathPromptValueOptions
+        options: GetTargetPathInputBoxValueOptions
     ): Promise<string> {
         const { workspaceFolderPath, pathType } = options;
 

--- a/src/controller/FileController.ts
+++ b/src/controller/FileController.ts
@@ -11,7 +11,7 @@ export interface ExecuteOptions {
     fileItem: FileItem;
 }
 
-export interface GetSourcePathOptions {
+export interface SourcePathOptions {
     relativeToRoot?: boolean;
     ignoreIfNotExists?: boolean;
     uri?: Uri;
@@ -23,5 +23,5 @@ export interface FileController {
     execute(options: ExecuteOptions): Promise<FileItem>;
     openFileInEditor(fileItem: FileItem): Promise<TextEditor | undefined>;
     closeCurrentFileEditor(): Promise<unknown>;
-    getSourcePath(options?: GetSourcePathOptions): Promise<string>;
+    getSourcePath(options?: SourcePathOptions): Promise<string>;
 }

--- a/src/controller/MoveFileController.ts
+++ b/src/controller/MoveFileController.ts
@@ -2,20 +2,11 @@ import expand from "brace-expansion";
 import * as path from "path";
 import { FileType, Uri, workspace } from "vscode";
 import { FileItem } from "../FileItem";
-import {
-    BaseFileController,
-    GetTargetPathInputBoxValueOptions as BaseGetTargetPathInputBoxValueOptions,
-} from "./BaseFileController";
+import { BaseFileController, GetTargetPathInputBoxValueOptions } from "./BaseFileController";
 import { DialogOptions, ExecuteOptions } from "./FileController";
 
-export interface MoveFileDialogOptions extends DialogOptions {
-    showPath?: boolean;
-}
-
-type GetTargetPathInputBoxValueOptions = BaseGetTargetPathInputBoxValueOptions & MoveFileDialogOptions;
-
 export class MoveFileController extends BaseFileController {
-    public async showDialog(options: MoveFileDialogOptions): Promise<FileItem | undefined> {
+    public async showDialog(options: DialogOptions): Promise<FileItem | undefined> {
         const { uri } = options;
         const sourcePath = await this.getSourcePath({ uri });
 
@@ -44,11 +35,7 @@ export class MoveFileController extends BaseFileController {
         sourcePath: string,
         options: GetTargetPathInputBoxValueOptions
     ): Promise<string> {
-        const { showPath } = options;
-        const value = showPath
-            ? await this.getFullTargetPathInputBoxValue(sourcePath, options)
-            : path.basename(sourcePath);
-
+        const value = await this.getFullTargetPathInputBoxValue(sourcePath, options);
         return super.getTargetPathInputBoxValue(value, options);
     }
 

--- a/src/controller/MoveFileController.ts
+++ b/src/controller/MoveFileController.ts
@@ -2,7 +2,7 @@ import expand from "brace-expansion";
 import * as path from "path";
 import { FileType, Uri, workspace } from "vscode";
 import { FileItem } from "../FileItem";
-import { BaseFileController, GetTargetPathInputBoxValueOptions } from "./BaseFileController";
+import { BaseFileController, TargetPathInputBoxValueOptions } from "./BaseFileController";
 import { DialogOptions, ExecuteOptions } from "./FileController";
 
 export class MoveFileController extends BaseFileController {
@@ -33,7 +33,7 @@ export class MoveFileController extends BaseFileController {
 
     protected async getTargetPathInputBoxValue(
         sourcePath: string,
-        options: GetTargetPathInputBoxValueOptions
+        options: TargetPathInputBoxValueOptions
     ): Promise<string> {
         const value = await this.getFullTargetPathInputBoxValue(sourcePath, options);
         return super.getTargetPathInputBoxValue(value, options);
@@ -41,7 +41,7 @@ export class MoveFileController extends BaseFileController {
 
     private async getFullTargetPathInputBoxValue(
         sourcePath: string,
-        options: GetTargetPathInputBoxValueOptions
+        options: TargetPathInputBoxValueOptions
     ): Promise<string> {
         const { typeahead, workspaceFolderPath } = options;
 

--- a/src/controller/MoveFileController.ts
+++ b/src/controller/MoveFileController.ts
@@ -4,7 +4,7 @@ import { FileType, Uri, workspace } from "vscode";
 import { FileItem } from "../FileItem";
 import {
     BaseFileController,
-    GetTargetPathPromptValueOptions as BaseGetTargetPathPromtValueOptions,
+    GetTargetPathInputBoxValueOptions as BaseGetTargetPathInputBoxValueOptions,
 } from "./BaseFileController";
 import { DialogOptions, ExecuteOptions } from "./FileController";
 
@@ -12,7 +12,7 @@ export interface MoveFileDialogOptions extends DialogOptions {
     showPath?: boolean;
 }
 
-type GetTargetPathPromptValueOptions = BaseGetTargetPathPromtValueOptions & MoveFileDialogOptions;
+type GetTargetPathInputBoxValueOptions = BaseGetTargetPathInputBoxValueOptions & MoveFileDialogOptions;
 
 export class MoveFileController extends BaseFileController {
     public async showDialog(options: MoveFileDialogOptions): Promise<FileItem | undefined> {
@@ -40,21 +40,21 @@ export class MoveFileController extends BaseFileController {
         return fileItem.move();
     }
 
-    protected async getTargetPathPromptValue(
+    protected async getTargetPathInputBoxValue(
         sourcePath: string,
-        options: GetTargetPathPromptValueOptions
+        options: GetTargetPathInputBoxValueOptions
     ): Promise<string> {
         const { showPath } = options;
         const value = showPath
-            ? await this.getFullTargetPathPromptValue(sourcePath, options)
+            ? await this.getFullTargetPathInputBoxValue(sourcePath, options)
             : path.basename(sourcePath);
 
-        return super.getTargetPathPromptValue(value, options);
+        return super.getTargetPathInputBoxValue(value, options);
     }
 
-    private async getFullTargetPathPromptValue(
+    private async getFullTargetPathInputBoxValue(
         sourcePath: string,
-        options: GetTargetPathPromptValueOptions
+        options: GetTargetPathInputBoxValueOptions
     ): Promise<string> {
         const { typeahead, workspaceFolderPath } = options;
 

--- a/src/controller/NewFileController.ts
+++ b/src/controller/NewFileController.ts
@@ -1,7 +1,7 @@
 import expand from "brace-expansion";
 import * as path from "path";
 import { FileItem } from "../FileItem";
-import { BaseFileController, GetTargetPathPromptValueOptions } from "./BaseFileController";
+import { BaseFileController, GetTargetPathInputBoxValueOptions } from "./BaseFileController";
 import { DialogOptions, ExecuteOptions, GetSourcePathOptions } from "./FileController";
 
 export interface NewFileDialogOptions extends Omit<DialogOptions, "uri"> {
@@ -37,12 +37,12 @@ export class NewFileController extends BaseFileController {
         }
     }
 
-    protected async getTargetPathPromptValue(
+    protected async getTargetPathInputBoxValue(
         sourcePath: string,
-        options: GetTargetPathPromptValueOptions
+        options: GetTargetPathInputBoxValueOptions
     ): Promise<string> {
         const value = path.join(sourcePath, path.sep);
-        return super.getTargetPathPromptValue(value, options);
+        return super.getTargetPathInputBoxValue(value, options);
     }
 
     public async getNewFileSourcePath({ relativeToRoot, typeahead }: GetSourcePathOptions): Promise<string> {

--- a/src/controller/NewFileController.ts
+++ b/src/controller/NewFileController.ts
@@ -1,8 +1,8 @@
 import expand from "brace-expansion";
 import * as path from "path";
 import { FileItem } from "../FileItem";
-import { BaseFileController, GetTargetPathInputBoxValueOptions } from "./BaseFileController";
-import { DialogOptions, ExecuteOptions, GetSourcePathOptions } from "./FileController";
+import { BaseFileController, TargetPathInputBoxValueOptions } from "./BaseFileController";
+import { DialogOptions, ExecuteOptions, SourcePathOptions } from "./FileController";
 
 export interface NewFileDialogOptions extends Omit<DialogOptions, "uri"> {
     relativeToRoot?: boolean;
@@ -39,13 +39,13 @@ export class NewFileController extends BaseFileController {
 
     protected async getTargetPathInputBoxValue(
         sourcePath: string,
-        options: GetTargetPathInputBoxValueOptions
+        options: TargetPathInputBoxValueOptions
     ): Promise<string> {
         const value = path.join(sourcePath, path.sep);
         return super.getTargetPathInputBoxValue(value, options);
     }
 
-    public async getNewFileSourcePath({ relativeToRoot, typeahead }: GetSourcePathOptions): Promise<string> {
+    public async getNewFileSourcePath({ relativeToRoot, typeahead }: SourcePathOptions): Promise<string> {
         const rootPath = await this.getRootPath(relativeToRoot === true);
 
         if (!rootPath) {

--- a/src/controller/RenameFileController.ts
+++ b/src/controller/RenameFileController.ts
@@ -1,0 +1,11 @@
+import * as path from "path";
+import { DialogOptions } from "./FileController";
+import { MoveFileController } from "./MoveFileController";
+
+export class RenameFileController extends MoveFileController {
+    protected async getTargetPath(sourcePath: string, options: DialogOptions): Promise<string | undefined> {
+        const { prompt } = options;
+        const value = path.basename(sourcePath);
+        return await this.showTargetPathInputBox({ prompt, value });
+    }
+}

--- a/src/controller/RenameFileController.ts
+++ b/src/controller/RenameFileController.ts
@@ -6,6 +6,11 @@ export class RenameFileController extends MoveFileController {
     protected async getTargetPath(sourcePath: string, options: DialogOptions): Promise<string | undefined> {
         const { prompt } = options;
         const value = path.basename(sourcePath);
-        return await this.showTargetPathInputBox({ prompt, value });
+        const targetPath = await this.showTargetPathInputBox({ prompt, value });
+
+        if (targetPath) {
+            const basePath = path.dirname(sourcePath);
+            return path.join(basePath, targetPath.replace(basePath, ""));
+        }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {
     NewFileController,
     RemoveFileController,
 } from "./controller";
+import { RenameFileController } from "./controller/RenameFileController";
 
 function handleError(err: Error) {
     if (err && err.message) {
@@ -32,19 +33,20 @@ function register(context: vscode.ExtensionContext, command: Command, commandNam
 }
 
 export function activate(context: vscode.ExtensionContext): void {
+    const copyFileNameController = new CopyFileNameController(context);
+    const duplicateFileController = new DuplicateFileController(context);
     const moveFileController = new MoveFileController(context);
     const newFileController = new NewFileController(context);
-    const duplicateFileController = new DuplicateFileController(context);
     const removeFileController = new RemoveFileController(context);
-    const copyFileNameController = new CopyFileNameController(context);
+    const renameFileController = new RenameFileController(context);
 
-    register(context, new MoveFileCommand(moveFileController), "moveFile");
-    register(context, new RenameFileCommand(moveFileController), "renameFile");
-    register(context, new DuplicateFileCommand(duplicateFileController), "duplicateFile");
-    register(context, new RemoveFileCommand(removeFileController), "removeFile");
-    register(context, new NewFileCommand(newFileController), "newFile");
-    register(context, new NewFileCommand(newFileController, { relativeToRoot: true }), "newFileAtRoot");
-    register(context, new NewFolderCommand(newFileController), "newFolder");
-    register(context, new NewFolderCommand(newFileController, { relativeToRoot: true }), "newFolderAtRoot");
     register(context, new CopyFileNameCommand(copyFileNameController), "copyFileName");
+    register(context, new DuplicateFileCommand(duplicateFileController), "duplicateFile");
+    register(context, new MoveFileCommand(moveFileController), "moveFile");
+    register(context, new NewFileCommand(newFileController, { relativeToRoot: true }), "newFileAtRoot");
+    register(context, new NewFileCommand(newFileController), "newFile");
+    register(context, new NewFolderCommand(newFileController, { relativeToRoot: true }), "newFolderAtRoot");
+    register(context, new NewFolderCommand(newFileController), "newFolder");
+    register(context, new RemoveFileCommand(removeFileController), "removeFile");
+    register(context, new RenameFileCommand(renameFileController), "renameFile");
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,5 @@
 import { workspace } from "vscode";
 
-export function getConfiguration<T>(key: string): T | undefined {
-    return workspace.getConfiguration("fileutils", null).get(key);
+export function getConfiguration<T>(key: string, defaultValue?: T): T | undefined {
+    return workspace.getConfiguration("fileutils", null).get(key) ?? defaultValue;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,5 @@
 import { workspace } from "vscode";
 
-export function getConfiguration<T>(key: string, defaultValue?: T): T | undefined {
-    return workspace.getConfiguration("fileutils", null).get(key) ?? defaultValue;
+export function getConfiguration<T>(key: string): T | undefined {
+    return workspace.getConfiguration("fileutils", null).get(key);
 }

--- a/test/command/DuplicateFileCommand.test.ts
+++ b/test/command/DuplicateFileCommand.test.ts
@@ -14,6 +14,7 @@ describe(DuplicateFileCommand.name, () => {
     beforeEach(async () => {
         await helper.beforeEach();
         helper.createGetConfigurationStub({ "duplicateFile.typeahead.enabled": false });
+        helper.createGetConfigurationStub({ "inputBox.path": "root" });
     });
 
     afterEach(helper.afterEach);

--- a/test/command/DuplicateFileCommand.test.ts
+++ b/test/command/DuplicateFileCommand.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import * as fs from "fs";
 import * as path from "path";
-import sinon from "sinon";
 import { Uri, window, workspace } from "vscode";
 import { DuplicateFileCommand } from "../../src/command/DuplicateFileCommand";
 import { DuplicateFileController } from "../../src/controller";
@@ -35,32 +34,13 @@ describe(DuplicateFileCommand.name, () => {
             helper.protocol.describe("when target destination exists", subject);
             helper.protocol.it("should open target file as active editor", subject);
 
-            describe("configuration", () => {
-                describe('when "newFile.typeahead.enabled" is "true"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "duplicateFile.typeahead.enabled": true });
-                        helper.createWorkspaceFoldersStub(helper.workspaceFolderA);
-                    });
+            helper.protocol.describe("typeahead configuration", subject, {
+                command: "duplicateFile",
+                items: helper.quickPick.typeahead.items.workspace,
+            });
 
-                    it("should show the quick pick dialog", async () => {
-                        await subject.execute();
-                        expect(window.showQuickPick).to.have.been.calledOnceWith(
-                            sinon.match(helper.quickPick.typeahead.items.workspace),
-                            sinon.match(helper.quickPick.typeahead.options)
-                        );
-                    });
-                });
-
-                describe('when "newFile.typeahead.enabled" is "false"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "duplicateFile.typeahead.enabled": false });
-                    });
-
-                    it("should not show the quick pick dialog", async () => {
-                        await subject.execute();
-                        expect(window.showQuickPick).to.have.not.been.called;
-                    });
-                });
+            helper.protocol.describe("inputBox configuration", subject, {
+                editorFile: helper.editorFile1,
             });
         });
 
@@ -95,7 +75,12 @@ describe(DuplicateFileCommand.name, () => {
                 const value = sourceDirectory.path;
                 const valueSelection = [value.length - (value.split(path.sep).pop() as string).length, value.length];
                 const prompt = "Duplicate As";
-                expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+                expect(window.showInputBox).to.have.been.calledWithExactly({
+                    prompt,
+                    value,
+                    valueSelection,
+                    ignoreFocusOut: true,
+                });
             });
 
             it("should duplicate current file to destination", async () => {

--- a/test/command/MoveFileCommand.test.ts
+++ b/test/command/MoveFileCommand.test.ts
@@ -12,6 +12,7 @@ describe(MoveFileCommand.name, () => {
     beforeEach(async () => {
         await helper.beforeEach();
         helper.createGetConfigurationStub({ "moveFile.typeahead.enabled": false });
+        helper.createGetConfigurationStub({ "inputBox.path": "root" });
     });
 
     afterEach(helper.afterEach);

--- a/test/command/MoveFileCommand.test.ts
+++ b/test/command/MoveFileCommand.test.ts
@@ -1,6 +1,3 @@
-import { expect } from "chai";
-import sinon from "sinon";
-import { window } from "vscode";
 import { MoveFileCommand } from "../../src/command";
 import { MoveFileController } from "../../src/controller";
 import * as helper from "../helper";
@@ -31,32 +28,13 @@ describe(MoveFileCommand.name, () => {
             helper.protocol.it("should move current file to destination", subject);
             helper.protocol.describe("with target file in non-existent nested directory", subject);
 
-            describe("configuration", () => {
-                describe('when "newFile.typeahead.enabled" is "true"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "moveFile.typeahead.enabled": true });
-                        helper.createWorkspaceFoldersStub(helper.workspaceFolderA);
-                    });
+            helper.protocol.describe("typeahead configuration", subject, {
+                command: "moveFile",
+                items: helper.quickPick.typeahead.items.workspace,
+            });
 
-                    it("should show the quick pick dialog", async () => {
-                        await subject.execute();
-                        expect(window.showQuickPick).to.have.been.calledOnceWith(
-                            sinon.match(helper.quickPick.typeahead.items.workspace),
-                            sinon.match(helper.quickPick.typeahead.options)
-                        );
-                    });
-                });
-
-                describe('when "newFile.typeahead.enabled" is "false"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "moveFile.typeahead.enabled": false });
-                    });
-
-                    it("should not show the quick pick dialog", async () => {
-                        await subject.execute();
-                        expect(window.showQuickPick).to.have.not.been.called;
-                    });
-                });
+            helper.protocol.describe("inputBox configuration", subject, {
+                editorFile: helper.editorFile1,
             });
         });
 

--- a/test/command/NewFileCommand.test.ts
+++ b/test/command/NewFileCommand.test.ts
@@ -11,6 +11,7 @@ describe(NewFileCommand.name, () => {
     beforeEach(async () => {
         await helper.beforeEach();
         helper.createGetConfigurationStub({ "newFile.typeahead.enabled": false });
+        helper.createGetConfigurationStub({ "inputBox.path": "root" });
     });
 
     afterEach(helper.afterEach);

--- a/test/command/NewFileCommand.test.ts
+++ b/test/command/NewFileCommand.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import * as fs from "fs";
 import * as path from "path";
-import sinon from "sinon";
 import { Uri, window, workspace } from "vscode";
 import { NewFileCommand } from "../../src/command";
 import { NewFileController } from "../../src/controller";
@@ -33,34 +32,22 @@ describe(NewFileCommand.name, () => {
             const prompt = "File Name";
             const value = path.join(path.dirname(helper.editorFile1.path), path.sep);
             const valueSelection = [value.length, value.length];
-            expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+            expect(window.showInputBox).to.have.been.calledWithExactly({
+                prompt,
+                value,
+                valueSelection,
+                ignoreFocusOut: true,
+            });
         });
 
-        describe("configuration", () => {
-            describe('"newFile.typeahead.enabled" is "true"', () => {
-                beforeEach(async () => {
-                    helper.createGetConfigurationStub({ "newFile.typeahead.enabled": true });
-                });
+        helper.protocol.describe("typeahead configuration", subject, {
+            command: "newFile",
+            items: helper.quickPick.typeahead.items.currentFile,
+        });
 
-                it("should show the quick pick dialog", async () => {
-                    await subject.execute();
-                    expect(window.showQuickPick).to.have.been.calledOnceWithExactly(
-                        sinon.match(helper.quickPick.typeahead.items.currentFile),
-                        sinon.match(helper.quickPick.typeahead.options)
-                    );
-                });
-            });
-
-            describe('"newFile.typeahead.enabled" is "false"', () => {
-                beforeEach(async () => {
-                    helper.createGetConfigurationStub({ "newFile.typeahead.enabled": false });
-                });
-
-                it("should not show the quick pick dialog", async () => {
-                    await subject.execute();
-                    expect(window.showQuickPick).to.have.not.been.called;
-                });
-            });
+        helper.protocol.describe("inputBox configuration", subject, {
+            editorFile: helper.editorFile1,
+            expectedPath: "",
         });
 
         it("should create the file at destination", async () => {
@@ -127,48 +114,17 @@ describe(NewFileCommand.name, () => {
                 const prompt = "File Name";
                 const value = path.join(helper.workspacePathA, path.sep);
                 const valueSelection = [value.length, value.length];
-                expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+                expect(window.showInputBox).to.have.been.calledWithExactly({
+                    prompt,
+                    value,
+                    valueSelection,
+                    ignoreFocusOut: true,
+                });
             });
 
-            describe("configuration", () => {
-                describe('when "newFile.typeahead.enabled" is "true"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": true });
-                    });
-
-                    it("should show the quick pick dialog", async () => {
-                        await subject.execute();
-                        expect(window.showQuickPick).to.have.been.calledOnceWith(
-                            sinon.match(helper.quickPick.typeahead.items.workspace),
-                            sinon.match(helper.quickPick.typeahead.options)
-                        );
-                    });
-                });
-
-                describe('when "newFile.typeahead.enabled" is "false"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": false });
-                    });
-
-                    it("should not show the quick pick dialog", async () => {
-                        await subject.execute();
-                        expect(window.showQuickPick).to.have.not.been.called;
-                    });
-                });
-
-                describe.skip('when "inputBox.path" equals "workspace"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "inputBox.path": "workspace" });
-                    });
-
-                    it("should show the quick pick dialog", async () => {
-                        await subject.execute();
-                        expect(window.showQuickPick).to.have.been.calledOnceWith(
-                            sinon.match(helper.quickPick.typeahead.items.currentFile),
-                            sinon.match(helper.quickPick.typeahead.options)
-                        );
-                    });
-                });
+            helper.protocol.describe("typeahead configuration", subject, {
+                command: "newFile",
+                items: helper.quickPick.typeahead.items.workspace,
             });
         });
 
@@ -189,7 +145,12 @@ describe(NewFileCommand.name, () => {
                 const prompt = "File Name";
                 const value = path.join(helper.workspaceFolderB.uri.fsPath, path.sep);
                 const valueSelection = [value.length, value.length];
-                expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+                expect(window.showInputBox).to.have.been.calledWithExactly({
+                    prompt,
+                    value,
+                    valueSelection,
+                    ignoreFocusOut: true,
+                });
             });
 
             describe("with open document", () => {
@@ -209,36 +170,9 @@ describe(NewFileCommand.name, () => {
                 });
             });
 
-            describe("configuration", () => {
-                describe('when "newFile.typeahead.enabled" is "true"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": true });
-                    });
-
-                    it("should show the quick pick dialog", async () => {
-                        await subject.execute();
-
-                        expect(window.showQuickPick).to.have.been.calledOnceWith(
-                            sinon.match(helper.quickPick.typeahead.items.workspace),
-                            sinon.match(helper.quickPick.typeahead.options)
-                        );
-                    });
-                });
-
-                describe('when "newFile.typeahead.enabled" is "false"', () => {
-                    beforeEach(async () => {
-                        helper.createGetConfigurationStub({ "newFile.typeahead.enabled": false });
-                    });
-
-                    it("should not show the quick pick dialog", async () => {
-                        try {
-                            await subject.execute();
-                            expect.fail("Must fail");
-                        } catch (e) {
-                            expect(window.showQuickPick).to.have.not.been.called;
-                        }
-                    });
-                });
+            helper.protocol.describe("typeahead configuration", subject, {
+                command: "newFile",
+                items: helper.quickPick.typeahead.items.workspace,
             });
         });
     });

--- a/test/command/RemoveFileCommand.test.ts
+++ b/test/command/RemoveFileCommand.test.ts
@@ -23,8 +23,6 @@ describe(RemoveFileCommand.name, () => {
 
             afterEach(async () => {
                 await helper.closeAllEditors();
-                helper.restoreShowInformationMessage();
-                helper.restoreGetConfiguration();
             });
 
             describe("configuration", () => {
@@ -99,8 +97,6 @@ describe(RemoveFileCommand.name, () => {
                 await helper.closeAllEditors();
                 helper.createShowInformationMessageStub();
             });
-
-            afterEach(async () => helper.restoreShowInformationMessage());
 
             it("should ignore the command call", async () => {
                 try {

--- a/test/command/RenameFileCommand.test.ts
+++ b/test/command/RenameFileCommand.test.ts
@@ -30,7 +30,12 @@ describe(RenameFileCommand.name, () => {
                 const prompt = "New Name";
                 const value = path.basename(helper.editorFile1.fsPath);
                 const valueSelection = [value.length - 9, value.length - 3];
-                expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+                expect(window.showInputBox).to.have.been.calledWithExactly({
+                    prompt,
+                    value,
+                    valueSelection,
+                    ignoreFocusOut: true,
+                });
             });
 
             helper.protocol.it("should move current file to destination", subject);
@@ -48,7 +53,12 @@ describe(RenameFileCommand.name, () => {
                     const prompt = "New Name";
                     const value = path.basename(helper.editorFile2.fsPath);
                     const valueSelection = [value.length - 9, value.length - 3];
-                    expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+                    expect(window.showInputBox).to.have.been.calledWithExactly({
+                        prompt,
+                        value,
+                        valueSelection,
+                        ignoreFocusOut: true,
+                    });
                 });
             });
         });

--- a/test/command/RenameFileCommand.test.ts
+++ b/test/command/RenameFileCommand.test.ts
@@ -2,13 +2,15 @@ import { expect } from "chai";
 import * as path from "path";
 import { Uri, window } from "vscode";
 import { RenameFileCommand } from "../../src/command";
-import { MoveFileController } from "../../src/controller";
+import { RenameFileController } from "../../src/controller/RenameFileController";
 import * as helper from "../helper";
 
 describe(RenameFileCommand.name, () => {
-    const subject = new RenameFileCommand(new MoveFileController(helper.createExtensionContext()));
+    const subject = new RenameFileCommand(new RenameFileController(helper.createExtensionContext()));
 
-    beforeEach(helper.beforeEach);
+    beforeEach(async () => {
+        await helper.beforeEach();
+    });
 
     afterEach(helper.afterEach);
 
@@ -21,7 +23,6 @@ describe(RenameFileCommand.name, () => {
 
             afterEach(async () => {
                 await helper.closeAllEditors();
-                helper.restoreShowInputBox();
             });
 
             it("should prompt for file destination", async () => {
@@ -57,8 +58,6 @@ describe(RenameFileCommand.name, () => {
                 await helper.closeAllEditors();
                 helper.createShowInputBoxStub();
             });
-
-            afterEach(() => helper.restoreShowInputBox());
 
             it("should ignore the command call", async () => {
                 try {

--- a/test/helper/callbacks.ts
+++ b/test/helper/callbacks.ts
@@ -1,7 +1,25 @@
 import { existsSync } from "fs";
-import { workspace } from "vscode";
-import { editorFile1, editorFile2, fixtureFile1, fixtureFile2, tmpDir } from "./environment";
-import { restoreGetConfiguration } from "./stubs";
+import path from "path";
+import { Uri, workspace } from "vscode";
+import {
+    editorFile1,
+    editorFile2,
+    fixtureFile1,
+    fixtureFile2,
+    tmpDir,
+    workspaceFolderA,
+    workspaceFolderB,
+} from "./environment";
+import {
+    restoreExecuteCommand,
+    restoreGetConfiguration,
+    restoreGetWorkspaceFolder,
+    restoreShowInformationMessage,
+    restoreShowInputBox,
+    restoreShowQuickPick,
+    restoreShowWorkspaceFolderPick,
+    restoreWorkspaceFolders,
+} from "./stubs";
 
 export async function beforeEach(): Promise<void> {
     if (existsSync(tmpDir.fsPath)) {
@@ -9,11 +27,30 @@ export async function beforeEach(): Promise<void> {
     }
     await workspace.fs.copy(fixtureFile1, editorFile1, { overwrite: true });
     await workspace.fs.copy(fixtureFile2, editorFile2, { overwrite: true });
+
+    await workspace.fs.createDirectory(Uri.file(path.resolve(tmpDir.fsPath, "dir-1")));
+    await workspace.fs.createDirectory(Uri.file(path.resolve(tmpDir.fsPath, "dir-2")));
+
+    await workspace.fs.createDirectory(workspaceFolderA.uri);
+    await workspace.fs.createDirectory(workspaceFolderB.uri);
+
+    await workspace.fs.createDirectory(Uri.file(path.resolve(workspaceFolderA.uri.fsPath, "dir-1")));
+    await workspace.fs.createDirectory(Uri.file(path.resolve(workspaceFolderA.uri.fsPath, "dir-2")));
+
+    await workspace.fs.createDirectory(Uri.file(path.resolve(workspaceFolderB.uri.fsPath, "dir-1")));
+    await workspace.fs.createDirectory(Uri.file(path.resolve(workspaceFolderB.uri.fsPath, "dir-2")));
 }
 
 export async function afterEach(): Promise<void> {
     if (existsSync(tmpDir.fsPath)) {
         await workspace.fs.delete(tmpDir, { recursive: true, useTrash: false });
     }
+    restoreExecuteCommand();
     restoreGetConfiguration();
+    restoreGetWorkspaceFolder();
+    restoreShowInformationMessage();
+    restoreShowInputBox();
+    restoreShowQuickPick();
+    restoreShowWorkspaceFolderPick();
+    restoreWorkspaceFolders();
 }

--- a/test/helper/environment.ts
+++ b/test/helper/environment.ts
@@ -1,6 +1,6 @@
 import * as os from "os";
 import * as path from "path";
-import { Uri } from "vscode";
+import { Uri, WorkspaceFolder } from "vscode";
 
 export const rootDir = path.resolve(__dirname, "..", "..", "..");
 export const tmpDir = Uri.file(path.resolve(os.tmpdir(), "vscode-fileutils-test"));
@@ -13,3 +13,9 @@ export const editorFile2 = Uri.file(path.resolve(tmpDir.fsPath, "file-2.rb"));
 
 export const targetFile = Uri.file(path.resolve(`${editorFile1.fsPath}.tmp`));
 export const targetFileWithDot = Uri.file(path.resolve(tmpDir.fsPath, ".eslintrc.json"));
+
+export const workspacePathA = path.join(tmpDir.fsPath, "workspaceA");
+export const workspacePathB = path.join(tmpDir.fsPath, "workspaceB");
+
+export const workspaceFolderA: WorkspaceFolder = { uri: Uri.file(workspacePathA), name: "a", index: 0 };
+export const workspaceFolderB: WorkspaceFolder = { uri: Uri.file(workspacePathB), name: "b", index: 1 };

--- a/test/helper/index.ts
+++ b/test/helper/index.ts
@@ -46,6 +46,7 @@ export const quickPick = {
         options: {
             placeHolder:
                 "First, select an existing path to create relative to (larger projects may take a moment to load)",
+            ignoreFocusOut: true,
         },
     },
 };

--- a/test/helper/index.ts
+++ b/test/helper/index.ts
@@ -25,6 +25,27 @@ export const protocol = {
 
 export const quickPick = {
     typeahead: {
-        placeHolder: "First, select an existing path to create relative to (larger projects may take a moment to load)",
+        items: {
+            workspace: [
+                { description: "- workspace root", label: "/" },
+                { description: undefined, label: "/dir-1" },
+                { description: undefined, label: "/dir-2" },
+            ],
+            currentFile: [
+                { description: "- current file", label: "/" },
+                { description: undefined, label: "/dir-1" },
+                { description: undefined, label: "/dir-2" },
+                { description: undefined, label: "/workspaceA" },
+                { description: undefined, label: "/workspaceA/dir-1" },
+                { description: undefined, label: "/workspaceA/dir-2" },
+                { description: undefined, label: "/workspaceB" },
+                { description: undefined, label: "/workspaceB/dir-1" },
+                { description: undefined, label: "/workspaceB/dir-2" },
+            ],
+        },
+        options: {
+            placeHolder:
+                "First, select an existing path to create relative to (larger projects may take a moment to load)",
+        },
     },
 };

--- a/test/helper/steps/describe.ts
+++ b/test/helper/steps/describe.ts
@@ -1,11 +1,19 @@
 import { expect } from "chai";
 import * as mocha from "mocha";
 import * as path from "path";
-import { window, workspace } from "vscode";
+import sinon from "sinon";
+import { QuickPickItem, Uri, window, workspace } from "vscode";
+import { quickPick } from "..";
 import { Command } from "../../../src/command";
-import { editorFile2, targetFile, tmpDir } from "../environment";
+import { editorFile2, targetFile, tmpDir, workspaceFolderA } from "../environment";
 import { closeAllEditors, readFile } from "../functions";
-import { createShowInformationMessageStub, createShowInputBoxStub } from "../stubs";
+import {
+    createGetConfigurationStub,
+    createGetWorkspaceFolderStub,
+    createShowInformationMessageStub,
+    createShowInputBoxStub,
+    createWorkspaceFoldersStub,
+} from "../stubs";
 import { FuncVoid, Step } from "./types";
 
 export const describe: Step = {
@@ -83,6 +91,84 @@ export const describe: Step = {
                 } catch {
                     expect(window.showInputBox).to.have.not.been.called;
                 }
+            });
+        };
+    },
+    "typeahead configuration"(subject: Command, options: { command: string; items: QuickPickItem[] }): FuncVoid {
+        const { command, items } = options;
+        return () => {
+            mocha.describe(`when "${command}.typeahead.enabled" is "true"`, () => {
+                mocha.beforeEach(async () => {
+                    createGetConfigurationStub({ [`${command}.typeahead.enabled`]: true });
+                    createWorkspaceFoldersStub(workspaceFolderA);
+                });
+
+                mocha.it("should show the quick pick dialog", async () => {
+                    await subject.execute();
+                    expect(window.showQuickPick).to.have.been.calledOnceWith(
+                        sinon.match(items),
+                        sinon.match(quickPick.typeahead.options)
+                    );
+                });
+            });
+
+            mocha.describe(`when "${command}.typeahead.enabled" is "false"`, () => {
+                mocha.beforeEach(async () => {
+                    createGetConfigurationStub({ [`${command}.typeahead.enabled`]: false });
+                });
+
+                mocha.it("should not show the quick pick dialog", async () => {
+                    await subject.execute();
+                    expect(window.showQuickPick).to.have.not.been.called;
+                });
+            });
+        };
+    },
+    "inputBox configuration"(subject: Command, options: { editorFile: Uri; expectedPath?: string }): FuncVoid {
+        const { editorFile, expectedPath } = options;
+        const runs = [
+            { pathType: "workspace", pathTypeIndicator: "@" },
+            { pathType: "workspace", pathTypeIndicator: "" },
+            { pathType: "workspace", pathTypeIndicator: ":" },
+            { pathType: "workspace", pathTypeIndicator: " " },
+        ];
+
+        return () => {
+            runs.forEach(({ pathType, pathTypeIndicator }) => {
+                mocha.describe(
+                    `when "inputBox.pathType" is "${pathType}" and "inputBox.pathTypeIndicator" is "${pathTypeIndicator}"`,
+                    () => {
+                        mocha.beforeEach(async () => {
+                            createGetConfigurationStub({
+                                "inputBox.pathType": pathType,
+                                "inputBox.pathTypeIndicator": pathTypeIndicator,
+                            });
+
+                            const workspaceFolder = path.dirname(editorFile.path);
+                            createWorkspaceFoldersStub({
+                                uri: Uri.file(workspaceFolder),
+                                name: "workspace-a",
+                                index: 0,
+                            });
+                            createGetWorkspaceFolderStub().returns(workspaceFolder);
+                        });
+
+                        mocha.it("should show the quick pick dialog", async () => {
+                            await subject.execute();
+
+                            const expectedValue = `${pathTypeIndicator}/${
+                                expectedPath ?? path.basename(editorFile.path)
+                            }`;
+
+                            expect(window.showInputBox).to.have.been.calledOnceWith({
+                                prompt: sinon.match.string,
+                                value: sinon.match(expectedValue),
+                                valueSelection: sinon.match.array,
+                                ignoreFocusOut: true,
+                            });
+                        });
+                    }
+                );
             });
         };
     },

--- a/test/helper/steps/describe.ts
+++ b/test/helper/steps/describe.ts
@@ -5,12 +5,7 @@ import { window, workspace } from "vscode";
 import { Command } from "../../../src/command";
 import { editorFile2, targetFile, tmpDir } from "../environment";
 import { closeAllEditors, readFile } from "../functions";
-import {
-    createShowInformationMessageStub,
-    createShowInputBoxStub,
-    restoreShowInformationMessage,
-    restoreShowInputBox,
-} from "../stubs";
+import { createShowInformationMessageStub, createShowInputBoxStub } from "../stubs";
 import { FuncVoid, Step } from "./types";
 
 export const describe: Step = {
@@ -40,8 +35,6 @@ export const describe: Step = {
                 await workspace.fs.copy(editorFile2, targetFile, { overwrite: true });
                 createShowInformationMessageStub().resolves({ title: "placeholder" });
             });
-
-            mocha.afterEach(async () => restoreShowInformationMessage());
 
             mocha.it("should prompt with confirmation dialog to overwrite destination file", async () => {
                 await subject.execute();
@@ -82,8 +75,6 @@ export const describe: Step = {
                 await closeAllEditors();
                 createShowInputBoxStub();
             });
-
-            mocha.afterEach(async () => restoreShowInputBox());
 
             mocha.it("should ignore the command call", async () => {
                 try {

--- a/test/helper/steps/it.ts
+++ b/test/helper/steps/it.ts
@@ -24,7 +24,12 @@ export const it: Step = {
             await subject.execute(editorFile1);
             const value = editorFile1.path;
             const valueSelection = [value.length - 9, value.length - 3];
-            expect(window.showInputBox).to.have.been.calledWithExactly({ prompt, value, valueSelection });
+            expect(window.showInputBox).to.have.been.calledWithExactly({
+                prompt,
+                value,
+                valueSelection,
+                ignoreFocusOut: true,
+            });
         };
     },
 };

--- a/test/helper/stubs.ts
+++ b/test/helper/stubs.ts
@@ -9,7 +9,7 @@ export function restoreExecuteCommand(): void {
     restoreObject(commands.executeCommand);
 }
 
-export function createGetConfigurationStub(keys: { [key: string]: boolean }): sinon.SinonStub {
+export function createGetConfigurationStub(keys: Record<string, string | boolean>): sinon.SinonStub {
     const config = { get: (key: string) => keys[key] };
     return createStubObject(workspace, "getConfiguration").returns(config);
 }

--- a/test/helper/stubs.ts
+++ b/test/helper/stubs.ts
@@ -1,5 +1,21 @@
 import * as sinon from "sinon";
-import { commands, window, workspace } from "vscode";
+import { commands, window, workspace, WorkspaceFolder } from "vscode";
+
+export function createGetWorkspaceFolderStub(): sinon.SinonStub {
+    return createStubObject(workspace, "getWorkspaceFolder");
+}
+
+export function restoreGetWorkspaceFolder(): void {
+    restoreObject(workspace.getWorkspaceFolder);
+}
+
+export function createWorkspaceFoldersStub(...workspaceFolders: WorkspaceFolder[]): sinon.SinonStub {
+    return createStubObject(workspace, "workspaceFolders").get(() => workspaceFolders);
+}
+
+export function restoreWorkspaceFolders(): void {
+    restoreObject(workspace.workspaceFolders);
+}
 
 export function createExecuteCommandStub(): sinon.SinonStub {
     return createStubObject(commands, "executeCommand");
@@ -32,6 +48,14 @@ export function createShowQuickPickStub(): sinon.SinonStub {
 
 export function restoreShowQuickPick(): void {
     restoreObject(window.showQuickPick);
+}
+
+export function createShowWorkspaceFolderPickStub(): sinon.SinonStub {
+    return createStubObject(window, "showWorkspaceFolderPick");
+}
+
+export function restoreShowWorkspaceFolderPick(): void {
+    restoreObject(window.showWorkspaceFolderPick);
 }
 
 export function createShowInformationMessageStub(): sinon.SinonStub {


### PR DESCRIPTION
# Description

### New configuration settings
`fileutils.inputBox.pathType`
Changes the path representation of all input boxes for the `newFile`, `newFolder`, `duplicateFile` and `moveFile` command.

`fileutils.pathTypeIndicator` 
Indicator prepended to the input box path. 
This setting only has an effect when `fileutils.inputBox.pathType` is set to `workspace`.


| `fileutils.inputBox.pathType` | `fileutils.inputBox.pathTypeIndicator` | path representation           |
|---------------------|------------------------------|-------------------------------|
| `root` (default)    | `@` (default)                | `/User/Documents/myWorkspace` |
| `workspace`         | `@` (default)                | `@/myWorkspace`               |
| `workspace`         | `>`                          | `>/myWorkspace`               |
| `workspace`         | `=`                          | `/myWorkspace`                |
  

Fixes #485, #506

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
