### PR TITLE
fix(MoveFileController): disable brace expansion

### DIFF
--- a/src/controller/MoveFileController.ts
+++ b/src/controller/MoveFileController.ts
@@ -1,4 +1,3 @@
-import expand from "brace-expansion";
 import * as path from "path";
 import { FileType, Uri, workspace } from "vscode";
 import { FileItem } from "../FileItem";
@@ -18,10 +17,7 @@ export class MoveFileController extends BaseFileController {
 
         if (targetPath) {
             const isDir = (await workspace.fs.stat(Uri.file(sourcePath))).type === FileType.Directory;
-
-            return expand(targetPath)
-                .map((filePath) => new FileItem(sourcePath, filePath, isDir))
-                .at(0);
+            return new FileItem(sourcePath, targetPath, isDir);
         }
     }
 


### PR DESCRIPTION
# Description

Remove brace expansion for the `renameFile`, `moveFile` and `duplicateFile` command.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
