### PR TITLE
fix(NewFileController): show workspace selector when relative to root

### DIFF
--- a/src/controller/BaseFileController.ts
+++ b/src/controller/BaseFileController.ts
@@ -194,6 +194,7 @@ export abstract class BaseFileController implements FileController {
         return postAPICallClipboardData;
     }
 
+    protected async getWorkspaceFolderPath(relativeToRoot?: boolean): Promise<string | undefined>;
     protected async getWorkspaceFolderPath(): Promise<string | undefined> {
         const workspaceFolder = await this.selectWorkspaceFolder();
         return workspaceFolder?.uri.fsPath;
@@ -207,6 +208,10 @@ export abstract class BaseFileController implements FileController {
         const sourcePath = await this.getSourcePath({ ignoreIfNotExists: true });
         const uri = Uri.file(sourcePath);
         return workspace.getWorkspaceFolder(uri) || window.showWorkspaceFolderPick();
+    }
+
+    protected get isMultiRootWorkspace(): boolean {
+        return workspace.workspaceFolders !== undefined && workspace.workspaceFolders.length > 1;
     }
 
     protected async getFileSourcePathAtRoot(rootPath: string, options: SourcePathOptions): Promise<string> {

--- a/test/command/NewFileCommand.test.ts
+++ b/test/command/NewFileCommand.test.ts
@@ -140,7 +140,7 @@ describe(NewFileCommand.name, () => {
 
             it("should show workspace selector", async () => {
                 await subject.execute();
-                expect(window.showWorkspaceFolderPick).to.have.been.calledWith();
+                expect(window.showWorkspaceFolderPick).to.have.been.called;
 
                 const prompt = "File Name";
                 const value = path.join(helper.workspaceFolderB.uri.fsPath, path.sep);
@@ -157,16 +157,19 @@ describe(NewFileCommand.name, () => {
                 beforeEach(async () => {
                     helper.createGetWorkspaceFolderStub().returns(helper.workspaceFolderB);
                     await helper.openDocument(helper.editorFile1);
+                    await subject.execute();
                 });
 
                 afterEach(async () => {
                     await helper.closeAllEditors();
                 });
 
+                it("should show workspace selector", async () => {
+                    expect(window.showWorkspaceFolderPick).to.have.been.called;
+                });
+
                 it("should select workspace for open file", async () => {
-                    await subject.execute();
                     expect(workspace.getWorkspaceFolder).to.have.been.calledWith(Uri.file(helper.editorFile1.fsPath));
-                    expect(window.showWorkspaceFolderPick).to.have.not.been.called;
                 });
             });
 


### PR DESCRIPTION
# Description

New File/Folder relative to project root:
- show the workspace folder selector for multi root workspaces

Fixes #482 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
